### PR TITLE
Update logic for making stationxml files

### DIFF
--- a/examples/make_stationxml_from_mt.py
+++ b/examples/make_stationxml_from_mt.py
@@ -27,7 +27,7 @@ ns_dict = {
 # Input Parameters
 # =============================================================================
 # path to the folder where all the xmls are
-xml_path = Path(r"c:\Users\jpeacock\OneDrive - DOI\mt\annas_connundrums\mth5_newer")
+xml_path = Path(r"c:\Users\jpeacock\OneDrive - DOI\mt\annas_connundrums\mth5")
 output_path = Path(r"c:\Users\jpeacock")
 
 # make an instance of MTML2StationXML where the input is the path to the folder
@@ -38,7 +38,7 @@ now = MTime(get_now_utc())
 today = f"{now.year}{now.month:02}{now.day:02}"
 # if you want to make one stationxml per station then you can loop over
 # stations
-for station in a.stations[-2:-1]:
+for station in ["CAZ09"]:
     mtex = a.make_experiment(stations=station)
 
     # name the file as network_year_station_today.xml

--- a/examples/make_stationxml_from_mt.py
+++ b/examples/make_stationxml_from_mt.py
@@ -38,7 +38,8 @@ now = MTime(get_now_utc())
 today = f"{now.year}{now.month:02}{now.day:02}"
 # if you want to make one stationxml per station then you can loop over
 # stations
-for station in ["CAZ09"]:
+# for station in a.stations:
+for station in ["CAR05"]:
     mtex = a.make_experiment(stations=station)
 
     # name the file as network_year_station_today.xml

--- a/mt_metadata/__init__.py
+++ b/mt_metadata/__init__.py
@@ -109,7 +109,7 @@ MT_EXPERIMENT_SINGLE_STATION = DATA_DIR.joinpath(
     "data/mt_xml/single_station_mt_experiment.xml"
 )
 MT_EXPERIMENT_MULTIPLE_RUNS = DATA_DIR.joinpath("data/mt_xml/multi_run_experiment.xml")
-
+MT_EXPERIMENT_MULTIPLE_RUNS_02 = DATA_DIR.joinpath("data/mt_xml/multi_run_experiment_02.xml")
 
 ### Transfer function files
 TF_ZMM = DATA_DIR.joinpath("data/transfer_functions/example_emtf.zmm")

--- a/mt_metadata/data/mt_xml/multi_run_experiment.xml
+++ b/mt_metadata/data/mt_xml/multi_run_experiment.xml
@@ -35,7 +35,7 @@
         </southeast_corner>
         <summary>None</summary>
         <time_period>
-            <end_date>2020-07-28</end_date>
+            <end_date>2020-07-29</end_date>
             <start_date>2020-07-05</start_date>
         </time_period>
         <filters>

--- a/mt_metadata/data/mt_xml/multi_run_experiment_02.xml
+++ b/mt_metadata/data/mt_xml/multi_run_experiment_02.xml
@@ -1,0 +1,4759 @@
+<?xml version="1.0" ?>
+<Experiment>
+    <survey>
+        <acquired_by>
+            <author>National Geoelectromagnetic Facility</author>
+        </acquired_by>
+        <citation_dataset>
+            <doi>https://doi.org/10.7914/SN/8P_2019</doi>
+        </citation_dataset>
+        <citation_journal>
+            <doi>None</doi>
+        </citation_journal>
+        <country>USA</country>
+        <datum>WGS84</datum>
+        <fdsn>
+            <network>8P</network>
+        </fdsn>
+        <geographic_name>Southern California, USA</geographic_name>
+        <id>CONUS SoCal</id>
+        <name>USMTArray SOCAL Magnetotelluric Time Series</name>
+        <northwest_corner>
+            <latitude units="degrees">38.24520275</latitude>
+            <longitude units="degrees">-120.381101</longitude>
+        </northwest_corner>
+        <project>USMTArray</project>
+        <project_lead>
+            <author>Adam Schultz and Esteban Bowles-Martinez</author>
+            <organization>Oregon State University</organization>
+            <email>adam.schultz@oregonstate.edu</email>
+        </project_lead>
+        <release_license>CC-BY</release_license>
+        <southeast_corner>
+            <latitude units="degrees">38.24520275</latitude>
+            <longitude units="degrees">-120.381101</longitude>
+        </southeast_corner>
+        <summary>None</summary>
+        <time_period>
+            <end_date>2019-12-06</end_date>
+            <start_date>2018-08-16</start_date>
+        </time_period>
+        <filters>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>practical to SI unit conversion</comments>
+                <gain>1e-06</gain>
+                <name>electric_si_units</name>
+                <type>coefficient</type>
+                <units_in>mV/km</units_in>
+                <units_out>V/m</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>analog to digital conversion (electric)</comments>
+                <gain>484733700000000.0</gain>
+                <name>electric_analog_to_digital</name>
+                <type>coefficient</type>
+                <units_in>V</units_in>
+                <units_out>count</units_out>
+            </coefficient_filter>
+            <pole_zero_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>NIMS electric field 1 pole Butterworth high pass (analog)</comments>
+                <gain>1.0</gain>
+                <name>electric_butterworth_high_pass</name>
+                <normalization_factor>1.00000000378188</normalization_factor>
+                <poles>
+                    <item>(-0.000167+0j)</item>
+                </poles>
+                <type>zpk</type>
+                <units_in>mV/km</units_in>
+                <units_out>mV/km</units_out>
+                <zeros>
+                    <item>0j</item>
+                </zeros>
+            </pole_zero_filter>
+            <pole_zero_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>NIMS electric field 5 pole Butterworth 0.5 low pass (analog)</comments>
+                <gain>1.0</gain>
+                <name>electric_butterworth_low_pass</name>
+                <normalization_factor>313383.493219835</normalization_factor>
+                <poles>
+                    <item>(-3.883009+11.951875j)</item>
+                    <item>(-3.883009-11.951875j)</item>
+                    <item>(-10.166194+7.386513j)</item>
+                    <item>(-10.166194-7.386513j)</item>
+                    <item>(-12.566371+0j)</item>
+                </poles>
+                <type>zpk</type>
+                <units_in>mV/km</units_in>
+                <units_out>mV/km</units_out>
+                <zeros/>
+            </pole_zero_filter>
+            <time_delay_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>time offset in seconds (digital)</comments>
+                <delay units="second">-0.285</delay>
+                <gain>1.0</gain>
+                <name>electric_time_offset</name>
+                <type>time delay</type>
+                <units_in>count</units_in>
+                <units_out>count</units_out>
+            </time_delay_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>Digital to Analog Conversion</comments>
+                <gain>2.44141221047903e-09</gain>
+                <name>electric_digital_to_analog</name>
+                <type>coefficient</type>
+                <units_in>count</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>back to practical units</comments>
+                <gain>1000000.0</gain>
+                <name>electric_practical_units</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>mV/km</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>practical to SI unit conversion</comments>
+                <gain>1e-09</gain>
+                <name>magnetic_si_units</name>
+                <type>coefficient</type>
+                <units_in>nT</units_in>
+                <units_out>T</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>unit conversion (magnetic)</comments>
+                <gain>100000000000.0</gain>
+                <name>magnetic_tesla_to_counts</name>
+                <type>coefficient</type>
+                <units_in>T</units_in>
+                <units_out>count</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>unit conversion (magnetic)</comments>
+                <gain>100000000000.0</gain>
+                <name>magnetic_nanotesla_to_counts</name>
+                <type>coefficient</type>
+                <units_in>nT</units_in>
+                <units_out>count</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>analog to digital conversion (magnetic)</comments>
+                <gain>100.0</gain>
+                <name>magnetic_analog_to_digital</name>
+                <type>coefficient</type>
+                <units_in>V</units_in>
+                <units_out>count</units_out>
+            </coefficient_filter>
+            <pole_zero_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>NIMS magnetic field 3 pole Butterworth 0.5 low pass (analog)</comments>
+                <gain>1.0</gain>
+                <name>magnetic_butterworth_low_pass</name>
+                <normalization_factor>2002.26936395594</normalization_factor>
+                <poles>
+                    <item>(-6.283185+10.882477j)</item>
+                    <item>(-6.283185-10.882477j)</item>
+                    <item>(-12.566371+0j)</item>
+                </poles>
+                <type>zpk</type>
+                <units_in>nT</units_in>
+                <units_out>V</units_out>
+                <zeros/>
+            </pole_zero_filter>
+            <time_delay_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>time offset in seconds (digital)</comments>
+                <delay units="second">-0.192</delay>
+                <gain>1.0</gain>
+                <name>hx_time_offset</name>
+                <type>time delay</type>
+                <units_in>count</units_in>
+                <units_out>count</units_out>
+            </time_delay_filter>
+            <time_delay_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>time offset in seconds (digital)</comments>
+                <delay units="second">-0.201</delay>
+                <gain>1.0</gain>
+                <name>hy_time_offset</name>
+                <type>time delay</type>
+                <units_in>count</units_in>
+                <units_out>count</units_out>
+            </time_delay_filter>
+            <time_delay_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>time offset in seconds (digital)</comments>
+                <delay units="second">-0.21</delay>
+                <gain>1.0</gain>
+                <name>hz_time_offset</name>
+                <type>time delay</type>
+                <units_in>count</units_in>
+                <units_out>count</units_out>
+            </time_delay_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>unit conversion (magnetic)</comments>
+                <gain>0.01</gain>
+                <name>magnetic_counts_to_nanotesla</name>
+                <type>coefficient</type>
+                <units_in>count</units_in>
+                <units_out>nT</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car02c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car03a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car03a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car03b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car03b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car03c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car03c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car04a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car04a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car05d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_car06d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_car07c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cas03a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cas03a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cas03b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cas03b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05e_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05e_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05f_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05f_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_cas05g_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas05g_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>81.0</gain>
+                <name>electric_dipole_length_cas06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>78.0</gain>
+                <name>electric_dipole_length_cas06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>81.0</gain>
+                <name>electric_dipole_length_cas06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>78.0</gain>
+                <name>electric_dipole_length_cas06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>81.0</gain>
+                <name>electric_dipole_length_cas06c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>78.0</gain>
+                <name>electric_dipole_length_cas06c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>81.0</gain>
+                <name>electric_dipole_length_cas06d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>78.0</gain>
+                <name>electric_dipole_length_cas06d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>81.0</gain>
+                <name>electric_dipole_length_cas06e_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>78.0</gain>
+                <name>electric_dipole_length_cas06e_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas07a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cas07a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas07b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cas07b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cas07c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cas07c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat03a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>95.0</gain>
+                <name>electric_dipole_length_cat03a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat03b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>95.0</gain>
+                <name>electric_dipole_length_cat03b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat03c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>95.0</gain>
+                <name>electric_dipole_length_cat03c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat04d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07e_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat07e_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cat08a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat08a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cat08b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat08b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cat08c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cat08c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau03a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cau03a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau03b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cau03b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau03c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cau03c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau03d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>96.0</gain>
+                <name>electric_dipole_length_cau03d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau04c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>96.0</gain>
+                <name>electric_dipole_length_cau05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>96.0</gain>
+                <name>electric_dipole_length_cau05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau05c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>96.0</gain>
+                <name>electric_dipole_length_cau05c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau05d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>96.0</gain>
+                <name>electric_dipole_length_cau05d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cau06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cau06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cau06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cau06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cau06c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cau06c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07e_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau07e_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau08a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau08a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau08b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau08b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau09d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cau10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav04d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_cav05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_cav05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cav05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_cav05c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav05c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cav06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cav06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cav06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_cav06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cav11d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw05c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw06c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw08a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_caw08a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw08c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_caw08c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_caw09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_caw09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_caw09b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_caw09b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_caw09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_caw09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_caw11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_caw11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>103.0</gain>
+                <name>electric_dipole_length_caw11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12e_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caw12e_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cax06a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax06a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cax06b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax06b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_cax06c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax06c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax07c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cax08a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax08a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cax08b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax08b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_cax08c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax08c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cax09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cax09b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax09b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cax09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>98.0</gain>
+                <name>electric_dipole_length_cax09d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax09d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax12a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax12a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax12b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cax12b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay08a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay08a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay08b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay08b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_cay12d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_caz09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_caz09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz09b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz09b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_caz09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_caz09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>106.0</gain>
+                <name>electric_dipole_length_caz10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_caz10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>106.0</gain>
+                <name>electric_dipole_length_caz10b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_caz10b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>106.0</gain>
+                <name>electric_dipole_length_caz10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>105.0</gain>
+                <name>electric_dipole_length_caz10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_caz11d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>87.0</gain>
+                <name>electric_dipole_length_caz12a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>87.0</gain>
+                <name>electric_dipole_length_caz12a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>86.0</gain>
+                <name>electric_dipole_length_caz12b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>87.0</gain>
+                <name>electric_dipole_length_caz12b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>86.0</gain>
+                <name>electric_dipole_length_caz12d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>87.0</gain>
+                <name>electric_dipole_length_caz12d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer04c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer05a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer05a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer05b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rer05b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_reu09a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>104.0</gain>
+                <name>electric_dipole_length_reu09a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_reu09b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>104.0</gain>
+                <name>electric_dipole_length_reu09b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_reu09c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>104.0</gain>
+                <name>electric_dipole_length_reu09c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>102.0</gain>
+                <name>electric_dipole_length_reu10d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11d_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_rex11d_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_rey12a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_rey12a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_rey12b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_rey12b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>101.0</gain>
+                <name>electric_dipole_length_rey12c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>99.0</gain>
+                <name>electric_dipole_length_rey12c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11a_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11a_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11b_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11b_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11c_ex</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <coefficient_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric field to voltage (multiply by dipole length)</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_length_ttx11c_ey</name>
+                <type>coefficient</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+            </coefficient_filter>
+            <pole_zero_filter>
+                <calibration_date>1980-01-01</calibration_date>
+                <comments>electric dipole for electric field</comments>
+                <gain>100.0</gain>
+                <name>electric_dipole_100.000</name>
+                <normalization_factor>1.0</normalization_factor>
+                <poles/>
+                <type>zpk</type>
+                <units_in>V/m</units_in>
+                <units_out>V</units_out>
+                <zeros/>
+            </pole_zero_filter>
+        </filters>
+        <station>
+            <channels_recorded>
+                <item>Hx</item>
+                <item>Hy</item>
+                <item>Hz</item>
+                <item>Ex</item>
+                <item>Ey</item>
+            </channels_recorded>
+            <data_type>MT</data_type>
+            <fdsn>
+                <id>CAR05</id>
+            </fdsn>
+            <geographic_name>Arnold, CA, USA</geographic_name>
+            <id>CAR05</id>
+            <location>
+                <latitude units="degrees">38.24520275</latitude>
+                <longitude units="degrees">-120.381101</longitude>
+                <elevation units="meters">1224.4625</elevation>
+                <declination>
+                    <comments>igrf.m by Drew Compston</comments>
+                    <model>IGRF-13</model>
+                    <value units="degrees">13.143275</value>
+                </declination>
+            </location>
+            <orientation>
+                <method>compass</method>
+                <reference_frame>geographic</reference_frame>
+            </orientation>
+            <provenance>
+                <creation_time>2021-10-27T18:17:54+00:00</creation_time>
+                <software>
+                    <author>Anna Kelbert, USGS</author>
+                    <version>2021-10-27</version>
+                    <name>mth5_metadata.m</name>
+                </software>
+                <submitter>
+                    <author>Anna Kelbert, USGS</author>
+                    <organization>USGS Geomagnetism Program</organization>
+                    <email>akelbert@usgs.gov</email>
+                </submitter>
+            </provenance>
+            <run_list>
+                <item>a</item>
+                <item>b</item>
+                <item>c</item>
+                <item>d</item>
+            </run_list>
+            <time_period>
+                <end>2019-08-07T15:15:03+00:00</end>
+                <start>2019-07-17T21:32:00+00:00</start>
+            </time_period>
+            <run>
+                <acquired_by>
+                    <author>Kristin Pratscher</author>
+                    <comments>L Array in forest clearing in -14 degrees south and east. Matinance road 300m to the east. Hard iron rich soil, woody leafy ground cover. Warm sunny day and russian b</comments>
+                </acquired_by>
+                <channels_recorded_auxiliary/>
+                <channels_recorded_electric>
+                    <item>ex</item>
+                    <item>ey</item>
+                </channels_recorded_electric>
+                <channels_recorded_magnetic>
+                    <item>hx</item>
+                    <item>hy</item>
+                    <item>hz</item>
+                </channels_recorded_magnetic>
+                <comments>NIMS file declination 15 replaced with IGRF declination 13.1454. Start time may be late by 1 second. Please check.</comments>
+                <data_logger>
+                    <id>2611-B1</id>
+                    <manufacturer>Barry Narod</manufacturer>
+                    <type>None</type>
+                    <model>NIMS</model>
+                    <timing_system>
+                        <drift units="seconds">0.0</drift>
+                        <type>GPS</type>
+                        <uncertainty units="seconds">1.0</uncertainty>
+                    </timing_system>
+                    <firmware>
+                        <author>Barry Narod</author>
+                        <version>None</version>
+                        <name>None</name>
+                    </firmware>
+                    <power_source>
+                        <type>battery</type>
+                        <comments>voltage measurements not recorded</comments>
+                    </power_source>
+                </data_logger>
+                <data_type>BB, LP</data_type>
+                <fdsn>
+                    <new_epoch>True</new_epoch>
+                </fdsn>
+                <id>a</id>
+                <metadata_by>
+                    <author>Kristin Pratscher and Jade Crosbie</author>
+                    <comments>Start time may be late by 1 second. Please check.</comments>
+                </metadata_by>
+                <sample_rate units="samples per second">1.0</sample_rate>
+                <time_period>
+                    <end>2019-07-17T22:07:02+00:00</end>
+                    <start>2019-07-17T21:32:00+00:00</start>
+                </time_period>
+                <magnetic>
+                    <channel_number>1</channel_number>
+                    <comments>x 0.01 to get nT, Hx base shift 0 nT</comments>
+                    <component>hx</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFN</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hx_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">13.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-17T22:07:02+00:00</end>
+                        <start>2019-07-17T21:32:00+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>2</channel_number>
+                    <comments>x 0.01 to get nT, Hy base shift 0 nT</comments>
+                    <component>hy</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFE</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hy_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">103.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-17T22:07:02+00:00</end>
+                        <start>2019-07-17T21:32:00+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>3</channel_number>
+                    <comments>x 0.01 to get nT, Hz base shift 0 nT</comments>
+                    <component>hz</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFZ</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hz_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">0.0</measurement_azimuth>
+                    <measurement_tilt units="degrees">90.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-17T22:07:02+00:00</end>
+                        <start>2019-07-17T21:32:00+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <electric>
+                    <channel_number>4</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ex</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">359.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17055</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17024</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-17T22:07:02+00:00</end>
+                        <start>2019-07-17T21:32:00+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+                <electric>
+                    <channel_number>5</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ey</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">89.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17041</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17039</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-17T22:07:02+00:00</end>
+                        <start>2019-07-17T21:32:00+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+            </run>
+            <run>
+                <acquired_by>
+                    <author>Kristin Pratscher</author>
+                    <comments>L Array in forest clearing in -14 degrees south and east. Matinance road 300m to the east. Hard iron rich soil, woody leafy ground cover. Warm sunny day and russian b</comments>
+                </acquired_by>
+                <channels_recorded_auxiliary/>
+                <channels_recorded_electric>
+                    <item>ex</item>
+                    <item>ey</item>
+                </channels_recorded_electric>
+                <channels_recorded_magnetic>
+                    <item>hx</item>
+                    <item>hy</item>
+                    <item>hz</item>
+                </channels_recorded_magnetic>
+                <comments>NIMS file declination 15 replaced with IGRF declination 13.1454. Found data gaps (6). Of these, 4 duplicate blocks [deleted]. Gaps of unknown length: 4 [217107; 217655; 339499; 340037].</comments>
+                <data_logger>
+                    <id>2611-B1</id>
+                    <manufacturer>Barry Narod</manufacturer>
+                    <type>None</type>
+                    <model>NIMS</model>
+                    <timing_system>
+                        <drift units="seconds">0.0</drift>
+                        <type>GPS</type>
+                        <uncertainty units="seconds">1.0</uncertainty>
+                    </timing_system>
+                    <firmware>
+                        <author>Barry Narod</author>
+                        <version>None</version>
+                        <name>None</name>
+                    </firmware>
+                    <power_source>
+                        <type>battery</type>
+                        <comments>voltage measurements not recorded</comments>
+                    </power_source>
+                </data_logger>
+                <data_type>BB, LP</data_type>
+                <fdsn>
+                    <new_epoch>False</new_epoch>
+                </fdsn>
+                <id>b</id>
+                <metadata_by>
+                    <author>Kristin Pratscher and Jade Crosbie</author>
+                    <comments>Found data gaps (6). Of these, 4 duplicate blocks [deleted]. Gaps of unknown length: 2{339499; 340037]. GPS used to compute length of 2 gaps [217107; 217655].</comments>
+                </metadata_by>
+                <sample_rate units="samples per second">1.0</sample_rate>
+                <time_period>
+                    <end>2019-07-28T21:02:38+00:00</end>
+                    <start>2019-07-17T22:21:05+00:00</start>
+                </time_period>
+                <magnetic>
+                    <channel_number>1</channel_number>
+                    <comments>x 0.01 to get nT, Hx base shift 0 nT</comments>
+                    <component>hx</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFN</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hx_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">13.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T21:02:38+00:00</end>
+                        <start>2019-07-17T22:21:05+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>2</channel_number>
+                    <comments>x 0.01 to get nT, Hy base shift 0 nT</comments>
+                    <component>hy</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFE</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hy_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">103.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T21:02:38+00:00</end>
+                        <start>2019-07-17T22:21:05+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>3</channel_number>
+                    <comments>x 0.01 to get nT, Hz base shift 0 nT</comments>
+                    <component>hz</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFZ</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hz_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">0.0</measurement_azimuth>
+                    <measurement_tilt units="degrees">90.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T21:02:38+00:00</end>
+                        <start>2019-07-17T22:21:05+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <electric>
+                    <channel_number>4</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ex</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">359.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17055</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17024</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-28T21:02:38+00:00</end>
+                        <start>2019-07-17T22:21:05+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+                <electric>
+                    <channel_number>5</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ey</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">89.1454</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17041</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17039</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-28T21:02:38+00:00</end>
+                        <start>2019-07-17T22:21:05+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+            </run>
+            <run>
+                <acquired_by>
+                    <author>Kristin Pratscher</author>
+                    <comments>L Array in forest clearing in -14 degrees south and east. Matinance road 300m to the east. Hard iron rich soil, woody leafy ground cover. Hot sunny day and russian buckets. Found data gaps (6). Of these, 4 duplicate blocks [deleted]. Gaps of unknown length: 2{339499; 340037]. GPS used to compute length of 2 gaps [217107; 217655]. Check polarity of both electrodes; electrodes were checked and all are connected accordingly. Replaced E/W electrode lines.</comments>
+                </acquired_by>
+                <channels_recorded_auxiliary/>
+                <channels_recorded_electric>
+                    <item>ex</item>
+                    <item>ey</item>
+                </channels_recorded_electric>
+                <channels_recorded_magnetic>
+                    <item>hx</item>
+                    <item>hy</item>
+                    <item>hz</item>
+                </channels_recorded_magnetic>
+                <comments>NIMS file declination 15 replaced with IGRF declination 13.1427.</comments>
+                <data_logger>
+                    <id>2611-B1</id>
+                    <manufacturer>Barry Narod</manufacturer>
+                    <type>None</type>
+                    <model>NIMS</model>
+                    <timing_system>
+                        <drift units="seconds">0.0</drift>
+                        <type>GPS</type>
+                        <uncertainty units="seconds">1.0</uncertainty>
+                    </timing_system>
+                    <firmware>
+                        <author>Barry Narod</author>
+                        <version>None</version>
+                        <name>None</name>
+                    </firmware>
+                    <power_source>
+                        <type>battery</type>
+                        <comments>voltage measurements not recorded</comments>
+                    </power_source>
+                </data_logger>
+                <data_type>BB, LP</data_type>
+                <fdsn>
+                    <new_epoch>False</new_epoch>
+                </fdsn>
+                <id>c</id>
+                <metadata_by>
+                    <author>Alex Kover and Jade Crosbie</author>
+                    <comments>Test run</comments>
+                </metadata_by>
+                <sample_rate units="samples per second">1.0</sample_rate>
+                <time_period>
+                    <end>2019-07-28T23:58:03+00:00</end>
+                    <start>2019-07-28T23:23:55+00:00</start>
+                </time_period>
+                <magnetic>
+                    <channel_number>1</channel_number>
+                    <comments>x 0.01 to get nT, Hx base shift 0 nT</comments>
+                    <component>hx</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFN</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hx_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">13.1427</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T23:58:03+00:00</end>
+                        <start>2019-07-28T23:23:55+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>2</channel_number>
+                    <comments>x 0.01 to get nT, Hy base shift 0 nT</comments>
+                    <component>hy</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFE</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hy_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">103.1427</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T23:58:03+00:00</end>
+                        <start>2019-07-28T23:23:55+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>3</channel_number>
+                    <comments>x 0.01 to get nT, Hz base shift 0 nT</comments>
+                    <component>hz</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFZ</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hz_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">0.0</measurement_azimuth>
+                    <measurement_tilt units="degrees">90.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-07-28T23:58:03+00:00</end>
+                        <start>2019-07-28T23:23:55+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <electric>
+                    <channel_number>4</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ex</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">359.1427</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17055</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17024</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-28T23:58:03+00:00</end>
+                        <start>2019-07-28T23:23:55+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+                <electric>
+                    <channel_number>5</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ey</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">89.1427</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17201</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17117</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-07-28T23:58:03+00:00</end>
+                        <start>2019-07-28T23:23:55+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+            </run>
+            <run>
+                <acquired_by>
+                    <author>Kristin Pratscher</author>
+                    <comments>L Array in forest clearing in -14 degrees south and east. Matinance road 300m to the east. Hard iron rich soil, woody leafy ground cover. Hot sunny day and russian bucket</comments>
+                </acquired_by>
+                <channels_recorded_auxiliary/>
+                <channels_recorded_electric>
+                    <item>ex</item>
+                    <item>ey</item>
+                </channels_recorded_electric>
+                <channels_recorded_magnetic>
+                    <item>hx</item>
+                    <item>hy</item>
+                    <item>hz</item>
+                </channels_recorded_magnetic>
+                <comments>NIMS file declination 15 replaced with IGRF declination 13.1425. Found data gaps (7). Of these, 7 duplicate blocks [deleted].</comments>
+                <data_logger>
+                    <id>2611-B1</id>
+                    <manufacturer>Barry Narod</manufacturer>
+                    <type>None</type>
+                    <model>NIMS</model>
+                    <timing_system>
+                        <drift units="seconds">0.0</drift>
+                        <type>GPS</type>
+                        <uncertainty units="seconds">1.0</uncertainty>
+                    </timing_system>
+                    <firmware>
+                        <author>Barry Narod</author>
+                        <version>None</version>
+                        <name>None</name>
+                    </firmware>
+                    <power_source>
+                        <type>battery</type>
+                        <comments>voltage measurements not recorded</comments>
+                    </power_source>
+                </data_logger>
+                <data_type>BB, LP</data_type>
+                <fdsn>
+                    <new_epoch>False</new_epoch>
+                </fdsn>
+                <id>d</id>
+                <metadata_by>
+                    <author>Alex Kover and Jade Crosbie</author>
+                    <comments>Error: 7 data gaps. Of these, 7 duplicate blocks deleted.</comments>
+                </metadata_by>
+                <sample_rate units="samples per second">1.0</sample_rate>
+                <time_period>
+                    <end>2019-08-07T15:15:03+00:00</end>
+                    <start>2019-07-29T00:26:06+00:00</start>
+                </time_period>
+                <magnetic>
+                    <channel_number>1</channel_number>
+                    <comments>x 0.01 to get nT, Hx base shift 0 nT</comments>
+                    <component>hx</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFN</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hx_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">13.1425</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-08-07T15:15:03+00:00</end>
+                        <start>2019-07-29T00:26:06+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>2</channel_number>
+                    <comments>x 0.01 to get nT, Hy base shift 0 nT</comments>
+                    <component>hy</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFE</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hy_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">103.1425</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-08-07T15:15:03+00:00</end>
+                        <start>2019-07-29T00:26:06+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <magnetic>
+                    <channel_number>3</channel_number>
+                    <comments>x 0.01 to get nT, Hz base shift 0 nT</comments>
+                    <component>hz</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <fdsn>
+                        <id>LFZ</id>
+                    </fdsn>
+                    <filter>
+                        <name>
+                            <item>magnetic_butterworth_low_pass</item>
+                            <item>magnetic_analog_to_digital</item>
+                            <item>hz_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <location>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </location>
+                    <measurement_azimuth units="degrees">0.0</measurement_azimuth>
+                    <measurement_tilt units="degrees">90.0</measurement_tilt>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <sensor>
+                        <id>2612-11</id>
+                        <manufacturer>Barry Narod</manufacturer>
+                        <type>Magnetometer</type>
+                        <model>fluxgate</model>
+                        <name>NIMS</name>
+                    </sensor>
+                    <time_period>
+                        <end>2019-08-07T15:15:03+00:00</end>
+                        <start>2019-07-29T00:26:06+00:00</start>
+                    </time_period>
+                    <type>magnetic</type>
+                    <units>counts</units>
+                </magnetic>
+                <electric>
+                    <channel_number>4</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ex</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">359.1425</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17055</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17024</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-08-07T15:15:03+00:00</end>
+                        <start>2019-07-29T00:26:06+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+                <electric>
+                    <channel_number>5</channel_number>
+                    <comments>x 2.4414e-06 to get mv, Gain 1</comments>
+                    <component>ey</component>
+                    <data_quality>
+                        <rating>
+                            <value>0</value>
+                        </rating>
+                    </data_quality>
+                    <dipole_length units="meters">100.0</dipole_length>
+                    <filter>
+                        <name>
+                            <item>electric_butterworth_low_pass</item>
+                            <item>electric_butterworth_high_pass</item>
+                            <item>electric_si_units</item>
+                            <item>electric_dipole_100.000</item>
+                            <item>electric_analog_to_digital</item>
+                            <item>electric_time_offset</item>
+                        </name>
+                        <applied>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                            <item>True</item>
+                        </applied>
+                    </filter>
+                    <measurement_azimuth units="degrees">89.1425</measurement_azimuth>
+                    <measurement_tilt units="degrees">0.0</measurement_tilt>
+                    <negative>
+                        <id>17041</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">0.0</latitude>
+                        <longitude units="degrees">0.0</longitude>
+                        <elevation units="meters">0.0</elevation>
+                    </negative>
+                    <positive>
+                        <id>17039</id>
+                        <manufacturer>Oregon State University</manufacturer>
+                        <type>Electrode</type>
+                        <model>Pb-PbCl2 kaolin gel Petiau 2 chamber type</model>
+                        <latitude units="degrees">38.24520275</latitude>
+                        <longitude units="degrees">-120.381101</longitude>
+                        <elevation units="meters">1224.4625</elevation>
+                    </positive>
+                    <sample_rate units="samples per second">1.0</sample_rate>
+                    <time_period>
+                        <end>2019-08-07T15:15:03+00:00</end>
+                        <start>2019-07-29T00:26:06+00:00</start>
+                    </time_period>
+                    <type>electric</type>
+                    <units>counts</units>
+                </electric>
+            </run>
+        </station>
+    </survey>
+</Experiment>

--- a/mt_metadata/timeseries/station.py
+++ b/mt_metadata/timeseries/station.py
@@ -212,6 +212,8 @@ class Station(Base):
             end.append(run.time_period.end)
 
         if start:
-            self.time_period.start = min(start)
+            if self.time_period.start > min(start):
+                self.time_period.start = min(start)
         if end:
-            self.time_period.end = max(end)
+            if self.time_period.end < max(end):
+                self.time_period.end = max(end)

--- a/mt_metadata/timeseries/survey.py
+++ b/mt_metadata/timeseries/survey.py
@@ -189,5 +189,7 @@ class Survey(Base):
             start.append(station.time_period.start)
             end.append(station.time_period.end)
 
-        self.time_period.start = min(start)
-        self.time_period.end = max(end)
+        if self.time_period.start > min(start):
+            self.time_period.start = min(start)
+        if self.time_period.end < max(end):
+            self.time_period.end = max(end)

--- a/mt_metadata/timeseries/tools/from_many_mt_files.py
+++ b/mt_metadata/timeseries/tools/from_many_mt_files.py
@@ -345,6 +345,8 @@ class MT2StationXML(XMLInventoryMTExperiment):
                         channel.location.elevation = station.location.elevation
             station.runs.append(r)
             dp_filters.update(dp)
+            
+        station.update_time_period()
 
         return station, dp_filters
 
@@ -378,6 +380,9 @@ class MT2StationXML(XMLInventoryMTExperiment):
             station, dp = self._make_station(station_dict)
             s.stations.append(station)
             dp_filters.update(dp)
+        
+        s.update_bounding_box()
+        s.update_time_period()
 
         return s, dp_filters
 

--- a/mt_metadata/timeseries/tools/from_many_mt_files.py
+++ b/mt_metadata/timeseries/tools/from_many_mt_files.py
@@ -12,7 +12,10 @@ from pathlib import Path
 import pandas as pd
 from xml.etree import cElementTree as et
 
-from mt_metadata.timeseries import Experiment, Survey, Station, Run, Electric, Magnetic
+from mt_metadata.timeseries import (
+    Experiment, Survey, Station, Run, Electric, Magnetic
+    )
+
 from mt_metadata.timeseries.filters import (
     PoleZeroFilter,
     CoefficientFilter,

--- a/tests/timeseries/stationxml/test_experiment_to_stationxml.py
+++ b/tests/timeseries/stationxml/test_experiment_to_stationxml.py
@@ -12,11 +12,12 @@ Created on Tue Feb 23 23:13:19 2021
 # Imports
 # =============================================================================
 import unittest
-from collections import OrderedDict
 
 from mt_metadata.timeseries import Experiment
 from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
-from mt_metadata import MT_EXPERIMENT_MULTIPLE_RUNS
+from mt_metadata import (
+    MT_EXPERIMENT_MULTIPLE_RUNS, MT_EXPERIMENT_MULTIPLE_RUNS_02
+    )
 
 # =============================================================================
 
@@ -45,7 +46,91 @@ class TestExperiment2StationXML(unittest.TestCase):
             len(self.inventory.networks[0].stations[0].channels),
             len(self.experiment.surveys[0].stations[0].runs[0].channels) + 3,
         )
+        
+    def test_channel_time_periods(self):
+        for code in ["LFN", "LFE", "LFZ", "LQN", "LQE"]:
+            channels = self.inventory.networks[0].stations[0].select(channel=code).channels
+            for ii, channel in enumerate(channels[1:], 0):
+                with self.subTest(f"{code} test start"):
+                    self.assertTrue(channels[ii].start_date < channel.start_date)
+                with self.subTest(f"{code} test end"):
+                    self.assertTrue(channels[ii].end_date < channel.end_date)
+                with self.subTest(f"{code} contintuity"):
+                    self.assertTrue(channels[ii].end_date < channel.start_date)
+                    
+    def test_station_time_periods(self):
+        with self.subTest("test station start time period in channels"):
+            c_start = [c.start_date for c in self.inventory.networks[0].stations[0].channels]
+            self.assertTrue(self.inventory.networks[0].stations[0].start_date <= min(c_start))
+         
+        with self.subTest("test station end time period in channels"):
+            c_end = [c.end_date for c in self.inventory.networks[0].stations[0].channels]
+            self.assertTrue(self.inventory.networks[0].stations[0].end_date >= max(c_end))
+            
+    def test_network_time_periods(self):
+        with self.subTest("test network start time period in stations"):
+            c_start = [c.start_date for c in self.inventory.networks[0].stations]
+            self.assertTrue(self.inventory.networks[0].start_date <= min(c_start))
+         
+        with self.subTest("test station end time period in channels"):
+            c_end = [c.end_date for c in self.inventory.networks[0].stations]
+            self.assertTrue(self.inventory.networks[0].end_date >= max(c_end))
 
+class TestExperiment2StationXML02(unittest.TestCase):
+    def setUp(self):
+        self.experiment = Experiment()
+        self.experiment.from_xml(fn=MT_EXPERIMENT_MULTIPLE_RUNS_02.as_posix())
+        self.translator = XMLInventoryMTExperiment()
+        self.maxDiff = None
+
+        self.inventory = self.translator.mt_to_xml(self.experiment)
+
+    def test_num_networks(self):
+        self.assertEqual(len(self.inventory.networks), len(self.experiment.surveys))
+
+    def test_num_stations(self):
+        self.assertEqual(
+            len(self.inventory.networks[0].stations),
+            len(self.experiment.surveys[0].stations),
+        )
+
+    def test_num_channels(self):
+        # the length is 10 because channel metadata changes.
+        self.assertEqual(
+            len(self.inventory.networks[0].stations[0].channels),
+            10,
+        )
+    
+    def test_channel_time_periods(self):
+        for code in ["LFN", "LFE", "LFZ", "LQN", "LQE"]:
+            channels = self.inventory.networks[0].stations[0].select(channel=code).channels
+            for ii, channel in enumerate(channels[1:], 0):
+                with self.subTest(f"{code} test start"):
+                    self.assertTrue(channels[ii].start_date < channel.start_date)
+                with self.subTest(f"{code} test end"):
+                    self.assertTrue(channels[ii].end_date < channel.end_date)
+                with self.subTest(f"{code} contintuity"):
+                    self.assertTrue(channels[ii].end_date < channel.start_date)
+              
+    def test_station_time_periods(self):
+        with self.subTest("test station start time period in channels"):
+            c_start = [c.start_date for c in self.inventory.networks[0].stations[0].channels]
+            self.assertTrue(self.inventory.networks[0].stations[0].start_date <= min(c_start))
+         
+        with self.subTest("test station end time period in channels"):
+            c_end = [c.end_date for c in self.inventory.networks[0].stations[0].channels]
+            self.assertTrue(self.inventory.networks[0].stations[0].end_date >= max(c_end))
+            
+    def test_network_time_periods(self):
+        with self.subTest("test network start time period in stations"):
+            c_start = [c.start_date for c in self.inventory.networks[0].stations]
+            self.assertTrue(self.inventory.networks[0].start_date <= min(c_start))
+         
+        with self.subTest("test station end time period in channels"):
+            c_end = [c.end_date for c in self.inventory.networks[0].stations]
+            self.assertTrue(self.inventory.networks[0].end_date >= max(c_end)) 
+    
+                    
 
 # =============================================================================
 # Run


### PR DESCRIPTION
- [x] When there are channels with different parameters the logic is to look at all existing channels, but if say a, b and d are all the same but c is not, then only c will be a new channel, but the time periods for the channels will over lap, and that is not a valid stationxml.  
- [x] When the station times are outside the bounds of a network stationxml validation fails, need to add a time period validation.
- [x] When the channel times are outside the bounds of a station stationxml validation fails, need to add a time period validation.
