### PR TITLE
Patch 104

### DIFF
--- a/mt_metadata/timeseries/experiment.py
+++ b/mt_metadata/timeseries/experiment.py
@@ -259,6 +259,13 @@ class Experiment(Base):
 
         """
 
+        if not isinstance(ex_dict, dict):
+            msg = f"experiemnt input must be a dictionary not {type(ex_dict)}"
+            self.logger.debug(msg)
+            raise TypeError(msg)
+        if "experiment" not in ex_dict.keys():
+            return
+
         for survey_dict in ex_dict["experiment"]["surveys"]:
             survey_object = Survey()
             survey_object.from_dict(survey_dict)

--- a/tests/timeseries/test_experiment.py
+++ b/tests/timeseries/test_experiment.py
@@ -207,6 +207,12 @@ class TestBuildExperiment(unittest.TestCase):
 
         self.assertTrue(ex == self.experiment)
 
+    def test_from_dict_fail(self):
+        self.assertRaises(TypeError, self.experiment.from_dict, 10)
+
+    def test_from_empty_dict(self):
+        self.assertEqual(None, self.experiment.from_dict({}))
+
 
 # =============================================================================
 # run


### PR DESCRIPTION
Fixes issue of trying to update an `Experiment.from_dict()` with an empty dictionary in MTH5.  

- [ ] Figure out a work around (if dictionary is empty pass)
- [ ] Update tests 