### PR TITLE
Make sure filter names are unique

### DIFF
--- a/mt_metadata/timeseries/filters/pole_zero_filter.py
+++ b/mt_metadata/timeseries/filters/pole_zero_filter.py
@@ -40,7 +40,7 @@ class PoleZeroFilter(FilterBase):
     @property
     def poles(self):
         """
-        
+
         :return: array of poles
         :rtype: np.ndarray
 
@@ -67,7 +67,7 @@ class PoleZeroFilter(FilterBase):
     @property
     def zeros(self):
         """
-        
+
         :return: array of zeros
         :rtype: np.ndarray
 
@@ -77,7 +77,7 @@ class PoleZeroFilter(FilterBase):
     @zeros.setter
     def zeros(self, value):
         """
-        
+
         Set the zeros, make sure the input is validated
         :param value: zero values
         :type value: list, tuple, np.ndarray
@@ -97,14 +97,14 @@ class PoleZeroFilter(FilterBase):
         """
         :return: number of poles
         :rtype: integer
-        
+
         """
         return len(self._poles)
 
     @property
     def n_zeros(self):
         """
-        
+
         :return: number of zeros
         :rtype: integer
 
@@ -113,18 +113,20 @@ class PoleZeroFilter(FilterBase):
 
     def zero_pole_gain_representation(self):
         """
-        
+
         :return: scipy.signal.ZPG object
         :rtype: :class:`scipy.signal.ZerosPolesGain`
 
         """
-        zpg = signal.ZerosPolesGain(self.zeros, self.poles, self.normalization_factor)
+        zpg = signal.ZerosPolesGain(
+            self.zeros, self.poles, self.normalization_factor
+        )
         return zpg
 
     @property
     def total_gain(self):
         """
-        
+
         :return: total gain of the filter
         :rtype: float
 
@@ -140,7 +142,7 @@ class PoleZeroFilter(FilterBase):
     ):
         """
         Convert the filter to an obspy filter
-        
+
         :param stage_number: sequential stage number, defaults to 1
         :type stage_number: integer, optional
         :param pz_type: Pole Zero type, defaults to "LAPLACE (RADIANS/SECOND)"
@@ -150,7 +152,7 @@ class PoleZeroFilter(FilterBase):
         :param sample_rate: sample rate, defaults to 1
         :type sample_rate: float, optional
         :return: Obspy stage filter
-        :rtype: :class:`obspy.core.inventory.PolesZerosResponseStage` 
+        :rtype: :class:`obspy.core.inventory.PolesZerosResponseStage`
 
         """
         if self.zeros is None:
@@ -187,7 +189,7 @@ class PoleZeroFilter(FilterBase):
         :rtype: np.ndarray
 
         """
-        angular_frequencies = 2 * np.pi * frequencies
+        angular_frequencies = 2 * np.pi * np.array(frequencies)
         w, h = signal.freqs_zpk(
             self.zeros, self.poles, self.total_gain, worN=angular_frequencies
         )

--- a/mt_metadata/timeseries/stationxml/xml_channel_mt_channel.py
+++ b/mt_metadata/timeseries/stationxml/xml_channel_mt_channel.py
@@ -516,26 +516,26 @@ class XMLChannelMTChannel(BaseTranslator):
         :rtype: TYPE
 
         """
-        new = True
+
         # check for existing filters
         for f_key, f_obj in existing_filters.items():
             if f_obj.type == mt_filter.type:
                 if round(abs(f_obj.complex_response([1])[0])) == round(
                     abs(mt_filter.complex_response([1])[0])
                 ):
-                    new = False
-                    return f_obj.name, new
+
+                    return f_obj.name, False
 
         try:
             last = sorted(
                 [k for k in existing_filters.keys() if mt_filter.type in k]
             )[-1]
         except IndexError:
-            return f"{mt_filter.type}_{0:02}", new
+            return f"{mt_filter.type}_{0:02}", True
         try:
-            return f"{mt_filter.type}_{int(last[-2:]) + 1:02}", new
+            return f"{mt_filter.type}_{int(last[-2:]) + 1:02}", True
         except ValueError:
-            return f"{mt_filter.type}_{0:02}", new
+            return f"{mt_filter.type}_{0:02}", True
 
     def _mt_to_xml_response(self, mt_channel, filters_dict, xml_channel):
         """

--- a/mt_metadata/timeseries/stationxml/xml_inventory_mt_experiment.py
+++ b/mt_metadata/timeseries/stationxml/xml_inventory_mt_experiment.py
@@ -73,7 +73,7 @@ class XMLInventoryMTExperiment:
                 mt_station = self.station_translator.xml_to_mt(xml_station)
                 for xml_channel in xml_station:
                     mt_channel, mt_filters = self.channel_translator.xml_to_mt(
-                        xml_channel
+                        xml_channel, mt_survey.filters
                     )
                     mt_survey.filters.update(mt_filters)
                     # if there is a run list match channel to runs
@@ -85,7 +85,9 @@ class XMLInventoryMTExperiment:
                             run_channel = deepcopy(mt_channel)
                             mt_run = mt_station.get_run(run_id)
                             # need to set the start and end time to the run
-                            run_channel.time_period.start = mt_run.time_period.start
+                            run_channel.time_period.start = (
+                                mt_run.time_period.start
+                            )
                             run_channel.time_period.end = mt_run.time_period.end
                             mt_run.add_channel(run_channel)
                     # if there are runs already try to match by start, end, sample_rate
@@ -103,13 +105,16 @@ class XMLInventoryMTExperiment:
                                     mt_run.time_period.start
                                     >= mt_channel.time_period.start
                                 ) and (
-                                    mt_run.time_period.end <= mt_channel.time_period.end
+                                    mt_run.time_period.end
+                                    <= mt_channel.time_period.end
                                 ):
                                     mt_run.channels.append(mt_channel)
                                     mt_run.sample_rate = mt_channel.sample_rate
                     # make a new run with generic information
                     else:
-                        mt_run = metadata.Run(id=f"{len(mt_station.runs)+1:03d}")
+                        mt_run = metadata.Run(
+                            id=f"{len(mt_station.runs)+1:03d}"
+                        )
                         mt_run.time_period.start = mt_channel.time_period.start
                         mt_run.time_period.end = mt_channel.time_period.end
                         mt_run.sample_rate = mt_channel.sample_rate
@@ -125,7 +130,9 @@ class XMLInventoryMTExperiment:
             mt_experiment.to_xml(fn=mt_fn)
         return mt_experiment
 
-    def mt_to_xml(self, mt_experiment, mt_fn=None, stationxml_fn=None, ns_dict=None):
+    def mt_to_xml(
+        self, mt_experiment, mt_fn=None, stationxml_fn=None, ns_dict=None
+    ):
         """
         Convert from MT :class:`mt_metadata.timeseries.Experiment` to
         :class:`obspy.core.inventory.Inventory`
@@ -158,7 +165,9 @@ class XMLInventoryMTExperiment:
                 xml_station = self.station_translator.mt_to_xml(mt_station)
                 xml_station.site.country = mt_survey.country
                 for mt_run in mt_station.runs:
-                    xml_station = self.add_run(xml_station, mt_run, mt_survey.filters)
+                    xml_station = self.add_run(
+                        xml_station, mt_run, mt_survey.filters
+                    )
                 xml_network.stations.append(xml_station)
             xml_inventory.networks.append(xml_network)
         if stationxml_fn:
@@ -184,20 +193,28 @@ class XMLInventoryMTExperiment:
         """
 
         for mt_channel in mt_run.channels:
-            xml_channel = self.channel_translator.mt_to_xml(mt_channel, filters_dict)
-            existing_channels = xml_station.select(channel=xml_channel.code).channels
+            xml_channel = self.channel_translator.mt_to_xml(
+                mt_channel, filters_dict
+            )
+            existing_channels = xml_station.select(
+                channel=xml_channel.code
+            ).channels
 
             if existing_channels:
                 find = False
                 start_list = [c.start_date for c in existing_channels]
-                existing_channel = existing_channels[start_list.index(max(start_list))]
+                existing_channel = existing_channels[
+                    start_list.index(max(start_list))
+                ]
                 # should only compare the last channel
                 # for existing_channel in existing_channels:
                 run_list = [c.value for c in existing_channel.comments]
                 # Compare channel metadata if matches just add run.id if its
                 # not already there.
                 self.logger.debug(
-                    "Comparing %s to %s", xml_channel.code, existing_channel.code
+                    "Comparing %s to %s",
+                    xml_channel.code,
+                    existing_channel.code,
                 )
                 if self.compare_xml_channel(xml_channel, existing_channel):
                     find = True
@@ -205,7 +222,9 @@ class XMLInventoryMTExperiment:
                         f"Matched {xml_channel.code}={existing_channel.code}"
                     )
                     if not mt_run.id in run_list:
-                        self.logger.debug(f"adding run id {mt_run.id} to {run_list}")
+                        self.logger.debug(
+                            f"adding run id {mt_run.id} to {run_list}"
+                        )
                         existing_channel.comments.append(
                             inventory.Comment(mt_run.id, subject="mt.run.id")
                         )
@@ -222,16 +241,22 @@ class XMLInventoryMTExperiment:
                     )
                     run_list = [c.value for c in xml_channel.comments]
                     if not mt_run.id in run_list:
-                        self.logger.debug(f"adding run id {mt_run.id} to {run_list}")
+                        self.logger.debug(
+                            f"adding run id {mt_run.id} to {run_list}"
+                        )
                         xml_channel.comments.append(
                             inventory.Comment(mt_run.id, subject="mt.run.id")
                         )
                     xml_station.channels.append(xml_channel)
             else:
-                self.logger.debug(f"no existing channels for {xml_channel.code}")
+                self.logger.debug(
+                    f"no existing channels for {xml_channel.code}"
+                )
                 run_list = [c.value for c in xml_channel.comments]
                 if not mt_run.id in run_list:
-                    self.logger.debug(f"adding run id {mt_run.id} to {run_list}")
+                    self.logger.debug(
+                        f"adding run id {mt_run.id} to {run_list}"
+                    )
                     xml_channel.comments.append(
                         inventory.Comment(mt_run.id, subject="mt.run.id")
                     )
@@ -260,14 +285,20 @@ class XMLInventoryMTExperiment:
             )
             return False
         if xml_channel_01.sensor != xml_channel_02.sensor:
-            self.logger.debug(f"{xml_channel_01.sensor} != {xml_channel_02.sensor}")
+            self.logger.debug(
+                f"{xml_channel_01.sensor} != {xml_channel_02.sensor}"
+            )
             return False
-        if round(xml_channel_01.latitude, 3) != round(xml_channel_02.latitude, 3):
+        if round(xml_channel_01.latitude, 3) != round(
+            xml_channel_02.latitude, 3
+        ):
             self.logger.debug(
                 f"{round(xml_channel_01.latitude, 3)} != {round(xml_channel_02.latitude, 3)}"
             )
             return False
-        if round(xml_channel_01.longitude, 3) != round(xml_channel_02.longitude, 3):
+        if round(xml_channel_01.longitude, 3) != round(
+            xml_channel_02.longitude, 3
+        ):
             self.logger.debug(
                 f"{round(xml_channel_01.longitude, 3)} != {round(xml_channel_02.longitude, 3)}"
             )

--- a/tests/timeseries/stationxml/test_renaming_filters.py
+++ b/tests/timeseries/stationxml/test_renaming_filters.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Oct 14 15:39:41 2022
+
+@author: jpeacock
+"""
+
+# =============================================================================
+# Imports
+# =============================================================================
+import unittest
+from collections import OrderedDict
+import numpy as np
+
+from obspy import read_inventory
+from mt_metadata.timeseries.stationxml import XMLChannelMTChannel
+from mt_metadata import STATIONXML_01
+from mt_metadata.timeseries.filters import PoleZeroFilter
+
+# =============================================================================
+
+
+class TestXMLChannelTwoChannels(unittest.TestCase):
+    """
+    Test reading XML channel to MT Channel
+    """
+
+    def setUp(self):
+        self.inventory = read_inventory(STATIONXML_01.as_posix())
+        for ch in self.inventory.networks[0].stations[0].channels:
+            for stage in ch.response.response_stages:
+                stage.name = None
+
+        self.converter = XMLChannelMTChannel()
+        self.maxDiff = None
+
+    def test_rename_filters(self):
+        mt_ch, ch_filter_dict = self.converter.xml_to_mt(
+            self.inventory.networks[0].stations[0].channels[0]
+        )
+
+        self.assertListEqual(
+            sorted(["zpk_00", "coefficient_00", "time delay_00"]),
+            sorted(ch_filter_dict.keys()),
+        )
+
+    def test_filter_exists(self):
+        pz = PoleZeroFilter(
+            **OrderedDict(
+                [
+                    ("calibration_date", "1980-01-01"),
+                    ("comments", "butterworth filter"),
+                    ("gain", 1.0),
+                    ("name", "zpk_00"),
+                    ("normalization_factor", 1984.31439386406),
+                    (
+                        "poles",
+                        np.array(
+                            [
+                                -6.283185 + 10.882477j,
+                                -6.283185 - 10.882477j,
+                                -12.566371 + 0.0j,
+                            ]
+                        ),
+                    ),
+                    ("type", "zpk"),
+                    ("units_in", "nT"),
+                    ("units_out", "V"),
+                    ("zeros", np.array([], dtype="complex128")),
+                ]
+            )
+        )
+        existing_dict = {pz.name: pz}
+
+        name, new = self.converter._add_filter_number(existing_dict, pz)
+        with self.subTest("name"):
+            self.assertEqual(name, pz.name)
+        with self.subTest("new"):
+            self.assertEqual(new, False)


### PR DESCRIPTION
When loading in filters from a stationxml the channel renames unnamed filters in sqequential order but only at the channel level.  This pull request adds the full filter dictionary to test against so that filters are not overwritten.  
