### PR TITLE
added test for null channel component

### DIFF
--- a/mt_metadata/timeseries/run.py
+++ b/mt_metadata/timeseries/run.py
@@ -271,7 +271,11 @@ class Run(Base):
         :rtype: TYPE
 
         """
-        return [ch.component for ch in self.channels.values()]
+        return [
+            ch.component
+            for ch in self.channels.values()
+            if ch.component is not None
+        ]
 
     @property
     def channels_recorded_electric(self):
@@ -279,7 +283,7 @@ class Run(Base):
             [
                 ch.component
                 for ch in self.channels.values()
-                if isinstance(ch, Electric)
+                if isinstance(ch, Electric) and ch.component is not None
             ]
         )
 
@@ -311,7 +315,7 @@ class Run(Base):
             [
                 ch.component
                 for ch in self.channels.values()
-                if isinstance(ch, Magnetic)
+                if isinstance(ch, Magnetic) and ch.component is not None
             ]
         )
 
@@ -343,7 +347,7 @@ class Run(Base):
             [
                 ch.component
                 for ch in self.channels.values()
-                if isinstance(ch, Auxiliary)
+                if isinstance(ch, Auxiliary) and ch.component is not None
             ]
         )
 

--- a/mt_metadata/timeseries/station.py
+++ b/mt_metadata/timeseries/station.py
@@ -107,7 +107,7 @@ class Station(Base):
         ch_list = []
         for run in self.runs:
             ch_list += run.channels_recorded_all
-        ch_list = sorted(set(ch_list))
+        ch_list = sorted(set([cc for cc in ch_list if cc is not None]))
         if self._channels_recorded == []:
             return ch_list
 


### PR DESCRIPTION
some more updates to make sure MTH5 works with ChannelTS and RunTS having a single metadata object `self._survey_metadata` under the hood.