### PR TITLE
Mth5 patch129 fixes

### DIFF
--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -186,14 +186,16 @@ class Base:
 
         """
         copied = type(self)()
-        for key in self.to_dict(single=True).keys():
+        for key in self.to_dict(single=True, required=False).keys():
             try:
+
                 copied.set_attr_from_name(
                     key, deepcopy(self.get_attr_from_name(key), memodict)
                 )
             # Need the TypeError for objects that have no __reduce__ method
             # like H5 references.
-            except (AttributeError, TypeError):
+            except (AttributeError, TypeError) as error:
+                self.logger.debug(error)
                 continue
         return copied
 

--- a/mt_metadata/timeseries/filters/channel_response_filter.py
+++ b/mt_metadata/timeseries/filters/channel_response_filter.py
@@ -206,9 +206,7 @@ class ChannelResponseFilter(Base):
         :return: all the time delay filters as a list
 
         """
-        delay_filters = [
-            x for x in self.filters_list if x.type == "time delay"
-        ]
+        delay_filters = [x for x in self.filters_list if x.type == "time delay"]
         return delay_filters
 
     @property
@@ -361,15 +359,13 @@ class ChannelResponseFilter(Base):
         units_out_obj = get_unit_object(self.units_out)
 
         total_response = inventory.Response()
-        total_response.instrument_sensitivity = (
-            inventory.InstrumentSensitivity(
-                total_sensitivity,
-                self.normalization_frequency,
-                units_in_obj.abbreviation,
-                units_out_obj.abbreviation,
-                input_units_description=units_in_obj.name,
-                output_units_description=units_out_obj.name,
-            )
+        total_response.instrument_sensitivity = inventory.InstrumentSensitivity(
+            total_sensitivity,
+            self.normalization_frequency,
+            units_in_obj.abbreviation,
+            units_out_obj.abbreviation,
+            input_units_description=units_in_obj.name,
+            output_units_description=units_out_obj.name,
         )
 
         for ii, f in enumerate(self.filters_list, 1):

--- a/mt_metadata/timeseries/filters/frequency_response_table_filter.py
+++ b/mt_metadata/timeseries/filters/frequency_response_table_filter.py
@@ -124,6 +124,7 @@ class FrequencyResponseTableFilter(FilterBase):
         :type value: np.ndarray
 
         """
+
         if isinstance(value, (list, tuple, np.ndarray)):
             self._empirical_phases = np.array(value, dtype=float)
 
@@ -224,13 +225,14 @@ class FrequencyResponseTableFilter(FilterBase):
 
         phase_response = interp1d(
             self.frequencies,
-            self.phases,
+            self._empirical_phases,
             kind=interpolation_method,
             fill_value="extrapolate",
         )
+
         amplitude_response = interp1d(
             self.frequencies,
-            self.amplitudes,
+            self._empirical_amplitudes,
             kind=interpolation_method,
             fill_value="extrapolate",
         )

--- a/mt_metadata/timeseries/filters/frequency_response_table_filter.py
+++ b/mt_metadata/timeseries/filters/frequency_response_table_filter.py
@@ -131,13 +131,13 @@ class FrequencyResponseTableFilter(FilterBase):
 
                 if self._empirical_phases.mean() > 1000 * np.pi / 2:
                     self.logger.warning(
-                        "Phases appear to be in milli radians attempting to conver to radians"
+                        "Phases appear to be in milli radians attempting to convert to radians"
                     )
                     self._empirical_phases = self._empirical_phases / 1000
 
                 elif np.abs(self._empirical_phases).max() > 6 * np.pi:
                     self.logger.warning(
-                        "Phases appear to be in degrees attempting to conver to radians"
+                        "Phases appear to be in degrees attempting to convert to radians"
                     )
                     self._empirical_phases = np.deg2rad(self._empirical_phases)
 

--- a/mt_metadata/transfer_functions/io/edi/metadata/standards/header.json
+++ b/mt_metadata/transfer_functions/io/edi/metadata/standards/header.json
@@ -192,7 +192,7 @@
         "style": "controlled vocabulary",
         "units": null,
         "description": "EDI standards version SEG 1.0",
-        "options": ["SEG 1.0", "1.0"],
+        "options": ["SEG 1.0", "1.0", "SEG_1.0"],
         "alias": [],
         "example": "SEG 1.0",
 		"default": "SEG 1.0"

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -39,8 +39,8 @@ leap_second_dict = {
     14: {"min": datetime.date(2006, 1, 1), "max": datetime.date(2009, 1, 1)},
     15: {"min": datetime.date(2009, 1, 1), "max": datetime.date(2012, 6, 30)},
     16: {"min": datetime.date(2012, 7, 1), "max": datetime.date(2015, 7, 1)},
-    17: {"min": datetime.date(2015, 7, 1), "max": datetime.date(2017, 1, 1)},
-    18: {"min": datetime.date(2017, 1, 1), "max": datetime.date(2022, 7, 1)},
+    17: {"min": datetime.date(2015, 7, 1), "max": datetime.date(2016, 12, 31)},
+    18: {"min": datetime.date(2017, 1, 1), "max": datetime.date(2025, 7, 1)},
 }
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -63,20 +63,25 @@ class TestBase(unittest.TestCase):
     def test_validate_type(self):
 
         with self.subTest("float"):
-            self.assertEqual(10.0, self.base_object._validate_type("10", "float"))
+            self.assertEqual(
+                10.0, self.base_object._validate_type("10", "float")
+            )
         with self.subTest("integer"):
             self.assertEqual(10, self.base_object._validate_type("10", int))
         with self.subTest("string"):
             self.assertEqual("10", self.base_object._validate_type(10, str))
         with self.subTest("bool"):
-            self.assertEqual(True, self.base_object._validate_type("true", bool))
+            self.assertEqual(
+                True, self.base_object._validate_type("true", bool)
+            )
 
     def test_list_validation_type(self):
 
         number_list = [10, "11", 12.6, "13.3"]
         with self.subTest("int"):
             self.assertEqual(
-                [10, 11, 12, 13], self.base_object._validate_type(number_list, int)
+                [10, 11, 12, 13],
+                self.base_object._validate_type(number_list, int),
             )
         with self.subTest("float"):
             self.assertEqual(
@@ -90,18 +95,31 @@ class TestBase(unittest.TestCase):
             )
         with self.subTest("bool"):
             self.assertEqual(
-                [True, False], self.base_object._validate_type(["true", "False"], bool)
+                [True, False],
+                self.base_object._validate_type(["true", "False"], bool),
             )
 
     def test_update(self):
         other = Base()
-        other.add_base_attribute(self.extra_name, self.extra_value, self.extra_v_dict)
+        other.add_base_attribute(
+            self.extra_name, self.extra_value, self.extra_v_dict
+        )
 
         other.extra_attribute = 12
 
         self.base_object.update(other)
 
         self.assertEqual(self.base_object, other)
+
+    def test_copy(self):
+        other = Base()
+        other.add_base_attribute(
+            self.extra_name, self.extra_value, self.extra_v_dict
+        )
+        other.extra_attribute = 12
+
+        new = other.copy()
+        self.assertEqual(other, new)
 
 
 # =============================================================================

--- a/tests/tf/io/edi/test_edi.py
+++ b/tests/tf/io/edi/test_edi.py
@@ -64,7 +64,10 @@ class TestEMeasurement(unittest.TestCase):
 
     def test_attr(self):
         for k, v in self.e_dict.items():
-            self.assertEqual(v, getattr(self.ex, k))
+            if isinstance(v, (float, int)):
+                self.assertAlmostEqual(v, getattr(self.ex, k))
+            else:
+                self.assertEqual(v, getattr(self.ex, k))
 
 
 class TestEMeasurementAZM(unittest.TestCase):
@@ -87,7 +90,7 @@ class TestEMeasurementAZM(unittest.TestCase):
             if k != "azm":
                 self.assertEqual(v, getattr(self.ex, k))
             else:
-                self.assertEqual(5.710593137499642, getattr(self.ex, k))
+                self.assertalmostEqual(5.7105931374996, getattr(self.ex, k))
 
 
 class TestHMeasurement(unittest.TestCase):

--- a/tests/tf/io/edi/test_edi.py
+++ b/tests/tf/io/edi/test_edi.py
@@ -90,7 +90,7 @@ class TestEMeasurementAZM(unittest.TestCase):
             if k != "azm":
                 self.assertEqual(v, getattr(self.ex, k))
             else:
-                self.assertalmostEqual(5.7105931374996, getattr(self.ex, k))
+                self.assertAlmostEqual(5.7105931374996, getattr(self.ex, k))
 
 
 class TestHMeasurement(unittest.TestCase):


### PR DESCRIPTION
A few more bug fixes

- [x] `metadata.Base.copy()` was only copying required attributes, which if set as an array of 0's was no longer required, so added flag in `__deepcopy__` for `required=False`. 