### PR TITLE
add a line to allow aux channel component to be empty

### DIFF
--- a/mt_metadata/timeseries/run.py
+++ b/mt_metadata/timeseries/run.py
@@ -2,7 +2,7 @@
 """
 Created on Wed Dec 23 21:30:36 2020
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -175,9 +175,10 @@ class Run(Base):
             self.logger.error(msg)
             raise ValueError(msg)
         if channel_obj.component is None:
-            msg = "component cannot be empty"
-            self.logger.error(msg)
-            raise ValueError(msg)
+            if not isinstance(channel_obj, Auxiliary):
+                msg = "component cannot be empty"
+                self.logger.error(msg)
+                raise ValueError(msg)
 
         if self.has_channel(channel_obj.component):
             self.channels[channel_obj.component].update(channel_obj)


### PR DESCRIPTION
I'm not sure if this is an appropriate change in logic but it eliminates the failures of the aurora NCEDC tests.