### PR TITLE
Mth5 patch129 fixes

### DIFF
--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -180,6 +180,7 @@ class Base:
     def __deepcopy__(self, memodict={}):
         """
         Need to skip copying the logger
+        need to copy properties as well.
 
         :return: DESCRIPTION
         :rtype: TYPE
@@ -197,6 +198,8 @@ class Base:
             except (AttributeError, TypeError) as error:
                 self.logger.debug(error)
                 continue
+        # need to copy and properties
+
         return copied
 
     def copy(self):

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -199,6 +199,15 @@ class Base:
                 self.logger.debug(error)
                 continue
         # need to copy and properties
+        for key in self.__dict__.keys():
+            if key.startswith("_"):
+                test_property = getattr(self.__class__, key[1:], None)
+                if isinstance(test_property, property):
+                    value = getattr(self, key[1:])
+                    if hasattr(value, "copy"):
+                        setattr(copied, key[1:], value.copy())
+                    else:
+                        setattr(copied, key[1:], value)
 
         return copied
 

--- a/mt_metadata/timeseries/station.py
+++ b/mt_metadata/timeseries/station.py
@@ -283,7 +283,8 @@ class Station(Base):
                     self.logger.error(msg)
                     raise ValueError(msg)
             run = run.replace("'", "").replace('"', "")
-            self.add_run(Run(id=run))
+            if run not in self.runs.keys():
+                self.add_run(Run(id=run))
 
     def update_time_period(self):
         """

--- a/mt_metadata/utils/list_dict.py
+++ b/mt_metadata/utils/list_dict.py
@@ -8,6 +8,7 @@ Created on Wed Nov 16 11:08:25 2022
 # Imports
 # =============================================================================
 from collections import OrderedDict
+from copy import deepcopy
 
 # =============================================================================
 
@@ -72,6 +73,31 @@ class ListDict:
             return obj.component
         else:
             raise TypeError("could not identify an appropriate key from object")
+
+    def __deepcopy__(self, memodict={}):
+        """
+        Need to skip copying the logger
+        need to copy properties as well.
+
+        :return: DESCRIPTION
+        :rtype: TYPE
+
+        """
+        copied = type(self)()
+        for key, value in self.items():
+            if hasattr(value, "copy"):
+                value = value.copy()
+            copied[key] = value
+
+        return copied
+
+    def copy(self):
+        """
+        Copy object
+
+        """
+
+        return self.__deepcopy__()
 
     def _get_index_slice_from_slice(self, items, key_slice):
         """

--- a/tests/test_list_dict.py
+++ b/tests/test_list_dict.py
@@ -56,6 +56,10 @@ class TestListDict(unittest.TestCase):
     def test_get_key_from_index_fail(self):
         self.assertRaises(KeyError, self.ld._get_key_from_index, 2)
 
+    def test_copy(self):
+        lc = self.ld.copy()
+        self.assertEqual(self.ld, lc)
+
 
 class TestListDictSetIndex(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Needed to update how metadata objects are copied.

- [x] Add `copy` method to `ListDict`
- [x] Update `metadata.Base.copy()`
- [x] Update tests