### PR TITLE
Update when an np.datetime64 is input

### DIFF
--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -153,7 +153,7 @@ class MTime:
                     "Input time is a np.datetime64 "
                     + "dt_object set to datetime64.tolist()."
                 )
-                self.dt_object = self.validate_tzinfo(time.tolist())
+                self.epoch_seconds = time.tolist() / 1e9
 
             elif isinstance(time, (datetime.datetime)):
                 self.logger.debug("Input time is a datetime.datetime object")

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -153,7 +153,16 @@ class MTime:
                     "Input time is a np.datetime64 "
                     + "dt_object set to datetime64.tolist()."
                 )
-                self.epoch_seconds = time.tolist() / 1e9
+                t = time.tolist()
+                if isinstance(t, datetime.datetime):
+                    self.dt_object = self.validate_tzinfo(t)
+                elif isinstance(t, int):
+                    if "ns" in time.dtype.descr[0][1]:
+                        self.epoch_seconds = t / 1e9
+                    elif "us" in time.dtype.descr[0][1]:
+                        self.epoch_seconds = t / 1e6
+                    elif "ms" in time.dtype.descr[0][1]:
+                        self.epoch_seconds = t / 1e3
 
             elif isinstance(time, (datetime.datetime)):
                 self.logger.debug("Input time is a datetime.datetime object")


### PR DESCRIPTION
If an np.datetime64 object is created from a string the `tolist()` method outputs a `datetime.datetime` object, which is handled fine.
If an np.datetime64 object is created from epoch seconds the `tolist()` method outputs an integer in the units of the epoch seconds, this is not handled yet.

- [x] Add test for `tolist()` output type
- [x] Add test for unit conversion for ns, us, ms.
- [x] Update tests