### PR TITLE
MTime and pandas Timestamp cannot handle large future or past dates

### DIFF
--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -129,6 +129,17 @@ class MTime:
         >>> t.year
         2020
 
+    .. note:: If the input data is greater than pandas.Timestamp.max then the
+     value is set to
+     :class:`pandas.Timestamp.max` = '2262-04-11 23:47:16.854775807'. Similarly,
+     If the input data is less than pandas.Timestamp.min then the value is
+     set to :class:`pandas.Timestamp.min` = '1677-09-21 00:12:43.145224193'
+
+
+    >>> t = MTime("3000-01-01")
+    [line 295] mt_metadata.utils.mttime.MTime.from_str -
+    INFO: 3000-01-01 is too large setting to 2262-04-11 23:47:16.854775807
+
     """
 
     def __init__(self, time=None, gps_time=False):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "concurrent-log-handler",
     "numpy",
-    "pandas",
+    "pandas<=1.5.3",
     "pyyaml",
     "obspy",
     "matplotlib",

--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -237,6 +237,14 @@ class TestMTime(unittest.TestCase):
 
         self.assertEqual(30, t2 - t1)
 
+    def test_too_large(self):
+        t1 = MTime("3000-01-01T00:00:00")
+        self.assertEqual(t1, pd.Timestamp.max)
+
+    def test_too_small(self):
+        t1 = MTime("1400-01-01T00:00:00")
+        self.assertEqual(t1, pd.Timestamp.min)
+
 
 # =============================================================================
 # Run


### PR DESCRIPTION
Fix Issue #128.  

If the a data above `pd.Timestamp.max` or below `pd.Timestamp.min` then an error is raised because it cannot be stored as nanoseconds.  For the purposes of the data `mt_metadata` and the MT suite of tools are using, it is real data with modern dates so we should set any large dates to `pd.Timestamp.max` and any early dates to `pd.Timestamp.min` without any issues. 

The main reason this comes up is queries to FDSN web services return an anonymous date as their earliest start to the year 3000, which is a bit optimistic. 

- [x] Add logic for min and max dates
- [x] Add tests
- [x] Add documentation 