### PR TITLE
Fix input time with `isoformat` attribute

### DIFF
--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -245,6 +245,14 @@ class TestMTime(unittest.TestCase):
         t1 = MTime("1400-01-01T00:00:00")
         self.assertEqual(t1, pd.Timestamp.min)
 
+    def test_utc_too_large(self):
+        t1 = MTime(UTCDateTime("3000-01-01"))
+        self.assertEqual(t1, pd.Timestamp.max)
+
+    def test_utc_too_small(self):
+        t1 = MTime(UTCDateTime("1400-01-01"))
+        self.assertEqual(t1, pd.Timestamp.min)
+
 
 # =============================================================================
 # Run


### PR DESCRIPTION
If a time is input as an object with an isoformat attribute like `datetime.datatime` or `obspy.UTCDataTime` and is larger than `pandas.Timestamp.max` or smaller than `pandas.Timestamp.min` then an error is raised, add logic to fix this issue.

- [x] Update Logic
- [x] Update tests
- [x] Update documentation