### PR TITLE
updating if a timedelta is subtracted

### DIFF
--- a/mt_metadata/timeseries/filters/filter_base.py
+++ b/mt_metadata/timeseries/filters/filter_base.py
@@ -83,8 +83,8 @@ class FilterBase(Base):
 
     @property
     def obspy_mapping(self):
-        """ 
-        
+        """
+
         :return: mapping to an obspy filter
         :rtype: dict
 
@@ -94,7 +94,7 @@ class FilterBase(Base):
     @property
     def name(self):
         """
-        
+
         :return: name of the filter
         :rtype: str
 
@@ -104,8 +104,8 @@ class FilterBase(Base):
     @name.setter
     def name(self, value):
         """
-        Set filter name 
-        
+        Set filter name
+
         :param value: name of filter
         :type value: sting
 
@@ -131,9 +131,9 @@ class FilterBase(Base):
     @property
     def calibration_date(self):
         """
-        
+
         :return: calibration date (YYYY-MM-DD)
-        :rtype: string 
+        :rtype: string
 
         """
         return self._calibration_dt.date
@@ -141,17 +141,17 @@ class FilterBase(Base):
     @calibration_date.setter
     def calibration_date(self, value):
         """
-        
+
         :param value: set calibration date (YYYY-MM-DD)
         :type value: string
 
         """
-        self._calibration_dt.from_str(value)
+        self._calibration_dt.parse(value)
 
     @property
     def total_gain(self):
         """
-        
+
         :return: Total gain of the filter
         :rtype: float
 
@@ -161,7 +161,7 @@ class FilterBase(Base):
     @property
     def units_in(self):
         """
-        
+
         :return: Input units of the filter
         :rtype: string
 
@@ -171,7 +171,7 @@ class FilterBase(Base):
     @units_in.setter
     def units_in(self, value):
         """
-        
+
         :param value: input units of the filter
         :type value: string
 
@@ -181,7 +181,7 @@ class FilterBase(Base):
     @property
     def units_out(self):
         """
-        
+
         :return: Output units of the filter
         :rtype: string
 
@@ -191,7 +191,7 @@ class FilterBase(Base):
     @units_out.setter
     def units_out(self, value):
         """
-        
+
         :param value: output units of the filter
         :type value: string
 
@@ -215,7 +215,7 @@ class FilterBase(Base):
     @classmethod
     def from_obspy_stage(cls, stage, mapping=None):
         """
-        
+
         :param cls: a filter object
         :type cls: filter object
         :param stage: Obspy stage filter
@@ -223,8 +223,8 @@ class FilterBase(Base):
         :param mapping: dictionary for mapping from an obspy stage,
             defaults to None
         :type mapping: dict, optional
-        :raises TypeError: If stage is not a 
-            :class:`obspy.inventory.response.ResponseStage` 
+        :raises TypeError: If stage is not a
+            :class:`obspy.inventory.response.ResponseStage`
         :return: the appropriate mt_metadata.timeseries.filter object
         :rtype: mt_metadata.timeseries.filter object
 
@@ -287,13 +287,19 @@ class FilterBase(Base):
 
         f_true = np.zeros_like(frequencies)
         for ii in range(0, f.size - window_len, 1):
-            cr_window = np.array(amp[ii : ii + window_len])  # / self.amplitudes.max()
-            test = abs(1 - np.log10(cr_window.min()) / np.log10(cr_window.max()))
+            cr_window = np.array(
+                amp[ii : ii + window_len]
+            )  # / self.amplitudes.max()
+            test = abs(
+                1 - np.log10(cr_window.min()) / np.log10(cr_window.max())
+            )
 
             if test <= tol:
                 f_true[(f >= f[ii]) & (f <= f[ii + window_len])] = 1
 
-        pb_zones = np.reshape(np.diff(np.r_[0, f_true, 0]).nonzero()[0], (-1, 2))
+        pb_zones = np.reshape(
+            np.diff(np.r_[0, f_true, 0]).nonzero()[0], (-1, 2)
+        )
 
         if pb_zones.shape[0] > 1:
             self.logger.debug(
@@ -357,7 +363,7 @@ class FilterBase(Base):
     @property
     def decimation_active(self):
         """
-        
+
         :return: if decimation is prescribed
         :rtype: bool
 

--- a/mt_metadata/timeseries/provenance.py
+++ b/mt_metadata/timeseries/provenance.py
@@ -46,4 +46,4 @@ class Provenance(Base):
 
     @creation_time.setter
     def creation_time(self, dt_str):
-        self._creation_dt.from_str(dt_str)
+        self._creation_dt.parse(dt_str)

--- a/mt_metadata/transfer_functions/io/edi/metadata/header.py
+++ b/mt_metadata/transfer_functions/io/edi/metadata/header.py
@@ -89,7 +89,7 @@ class Header(Location):
     @acqdate.setter
     def acqdate(self, value):
         try:
-            self._acqdate.from_str(value)
+            self._acqdate.parse(value)
         except MTTimeError as error:
             msg = f"Cannot set Header.acqdata with {value}. {error}"
             self.logger.debug(msg)
@@ -102,7 +102,7 @@ class Header(Location):
     @enddate.setter
     def enddate(self, value):
         try:
-            self._enddate.from_str(value)
+            self._enddate.parse(value)
         except MTTimeError as error:
             msg = f"Cannot set Header.enddata with {value}. {error}"
             self.logger.debug(msg)
@@ -114,7 +114,7 @@ class Header(Location):
     @filedate.setter
     def filedate(self, value):
         try:
-            self._filedate.from_str(value)
+            self._filedate.parse(value)
         except MTTimeError as error:
             msg = f"Cannot set Header.filedata with {value}. {error}"
             self.logger.debug(msg)
@@ -126,7 +126,7 @@ class Header(Location):
     @progdate.setter
     def progdate(self, value):
         try:
-            self._progdate.from_str(value)
+            self._progdate.parse(value)
         except MTTimeError as error:
             msg = f"Cannot set Header.progdata with {value}. {error}"
             self.logger.debug(msg)
@@ -204,7 +204,10 @@ class Header(Location):
                 setattr(self, key, value)
 
     def write_header(
-        self, longitude_format="LON", latlon_format="dms", required=True,
+        self,
+        longitude_format="LON",
+        latlon_format="dms",
+        required=True,
     ):
         """
         Write header information to a list of lines.

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/comment.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/comment.py
@@ -35,4 +35,4 @@ class Comment(Base):
 
     @date.setter
     def date(self, dt_str):
-        self._dt.from_str(dt_str)
+        self._dt.parse(dt_str)

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/field_notes.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/field_notes.py
@@ -46,7 +46,7 @@ class FieldNotes(Base):
 
     @start.setter
     def start(self, value):
-        self._start_dt.from_str(value)
+        self._start_dt.parse(value)
 
     @property
     def end(self):
@@ -54,4 +54,4 @@ class FieldNotes(Base):
 
     @end.setter
     def end(self, value):
-        self._end_dt.from_str(value)
+        self._end_dt.parse(value)

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/provenance.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/provenance.py
@@ -42,4 +42,4 @@ class Provenance(Base):
 
     @create_time.setter
     def create_time(self, dt_str):
-        self._creation_dt.from_str(dt_str)
+        self._creation_dt.parse(dt_str)

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
@@ -48,7 +48,7 @@ class Site(Base):
 
     @start.setter
     def start(self, value):
-        self._start_dt.from_str(value)
+        self._start_dt.parse(value)
 
     @property
     def end(self):
@@ -56,7 +56,7 @@ class Site(Base):
 
     @end.setter
     def end(self, value):
-        self._end_dt.from_str(value)
+        self._end_dt.parse(value)
 
     @property
     def year_collected(self):

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/software.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/software.py
@@ -36,4 +36,4 @@ class Software(Base):
 
     @last_mod.setter
     def last_mod(self, value):
-        self._last_mod_dt.from_str(value)
+        self._last_mod_dt.parse(value)

--- a/mt_metadata/transfer_functions/tf/comment.py
+++ b/mt_metadata/transfer_functions/tf/comment.py
@@ -32,4 +32,4 @@ class Comment(Base):
 
     @date.setter
     def date(self, dt_str):
-        self._dt.from_str(dt_str)
+        self._dt.parse(dt_str)

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -244,10 +244,31 @@ class MTime:
 
         """
 
-        if not isinstance(other, MTime):
+        if isinstance(other, (int, float)):
+            other = pd.Timedelta(seconds=other)
+            self.logger.debug("Assuming other time is in seconds")
+
+        elif isinstance(other, (datetime.timedelta, np.timedelta64)):
+            other = pd.Timedelta(other)
+
+        else:
+            try:
+                other = MTime(other)
+            except ValueError as error:
+                raise TypeError(error)
+
+        if not isinstance(other, (pd.Timedelta, MTime)):
+            msg = "Subtracting times must be either timedelta or another time."
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+        if isinstance(other, MTime):
             other = MTime(other)
 
-        return (self._time_stamp - other._time_stamp).total_seconds()
+            return (self._time_stamp - other._time_stamp).total_seconds()
+
+        elif isinstance(other, pd.Timedelta):
+            return MTime(self._time_stamp - other)
 
     def __hash__(self):
         return hash(self.isoformat())

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -288,7 +288,7 @@ class MTime:
     @epoch_seconds.setter
     def epoch_seconds(self, seconds):
         self.logger.debug(
-            "reading time from epoch seconds, assuming UTC " + "time zone"
+            "reading time from epoch seconds, assuming UTC time zone"
         )
         self._time_stamp = pd.Timestamp(seconds, tz="UTC")
 
@@ -354,6 +354,14 @@ class MTime:
                 stamp, t_min_max = self._fix_out_of_bounds_time_stamp(
                     dt_str.isoformat()
                 )
+
+        elif isinstance(dt_str, (float, int)):
+            if dt_str / 3e8 < 1e3:
+                stamp = pd.Timestamp(dt_str, unit="s")
+                self.logger.info("assuming input is in seconds")
+            else:
+                stamp = pd.Timestamp(dt_str, unit="ns")
+                self.logger.info("assuming input is in nanoseconds")
 
         else:
             try:

--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -237,6 +237,12 @@ class TestMTime(unittest.TestCase):
 
         self.assertEqual(30, t2 - t1)
 
+    def test_subtract_timedelta(self):
+        t1 = MTime(self.dt_true)
+        t2 = pd.Timedelta(seconds=30)
+
+        self.assertEqual(MTime("2020-01-02T12:14:50.123000+00:00"), t1 - t2)
+
     def test_too_large(self):
         t1 = MTime("3000-01-01T00:00:00")
         self.assertEqual(t1, pd.Timestamp.max)
@@ -252,6 +258,11 @@ class TestMTime(unittest.TestCase):
     def test_utc_too_small(self):
         t1 = MTime(UTCDateTime("1400-01-01"))
         self.assertEqual(t1, pd.Timestamp.min)
+
+    def test_gps_time(self):
+        t1 = MTime(self.dt_true, gps_time=True)
+        gps_time = MTime(self.dt_true) - 13
+        self.assertTrue(gps_time, t1)
 
 
 # =============================================================================

--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -64,6 +64,11 @@ class TestMTime(unittest.TestCase):
 
         self.assertEqual(t, self.dt_true)
 
+    def test_input_seconds_fail(self):
+        t = MTime(gps_time=True)
+
+        self.assertRaises(ValueError, t.parse, 10)
+
     def test_pd_timestamp(self):
         stamp = pd.Timestamp(self.dt_true)
 
@@ -80,7 +85,7 @@ class TestMTime(unittest.TestCase):
 
     def test_string_input_dt(self):
         t = MTime()
-        t.from_str(self.dt_str_01)
+        t.parse(self.dt_str_01)
 
         for key in self.keys:
             with self.subTest(key):
@@ -169,7 +174,7 @@ class TestMTime(unittest.TestCase):
 
     def test_input_fail(self):
         t = MTime()
-        self.assertRaises(ValueError, t.from_str, self.input_fail)
+        self.assertRaises(ValueError, t.parse, self.input_fail)
 
     def test_compare_dt(self):
         dt_01 = MTime()

--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -54,6 +54,16 @@ class TestMTime(unittest.TestCase):
             with self.subTest(key):
                 self.assertEqual(getattr(self, key), getattr(t, key))
 
+    def test_input_epoch_seconds(self):
+        t = MTime(self.epoch_seconds)
+
+        self.assertEqual(t, self.dt_true)
+
+    def test_input_epoch_nanoseconds(self):
+        t = MTime(self.epoch_seconds * 1e9)
+
+        self.assertEqual(t, self.dt_true)
+
     def test_pd_timestamp(self):
         stamp = pd.Timestamp(self.dt_true)
 


### PR DESCRIPTION
if a timedelta is subtracted from `MTime` an error is thrown, this fixes that error.

- [x] Need to return `MTime` if the subtracted object is a timedelta
- [x] Need to return total seconds if the subtracted object is another MTime
- [ ] Update tests