### PR TITLE
Add handling for attachement None

### DIFF
--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/attachment.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/attachment.py
@@ -2,7 +2,7 @@
 """
 Created on Wed Dec 23 21:30:36 2020
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -29,6 +29,8 @@ class Attachment(Base):
         super().__init__(attr_dict=attr_dict, **kwargs)
 
     def read_dict(self, input_dict):
+        if input_dict["attachment"] is None:
+            return
         helpers._read_element(self, input_dict, "attachment")
 
     def to_xml(self, string=False, required=True):


### PR DESCRIPTION
Two errors encountered in issue #156 

- [x] Add handling for attachment None
Fixed attachment None error in the sense that the TF loads.  It is not clear if the attachment is supposed to be allowed to have the value None.  @kujaku11 Can you check if this.  The TF is attached to issue #156 .

- [x] Error parsing orientation
