### PR TITLE
added logic for if channel location values are None

### DIFF
--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/electric.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/electric.py
@@ -40,8 +40,12 @@ class Electric(Base):
         :rtype: TYPE
 
         """
-        if self.orientation is None:
-            self.orientation = 0.0
+
+        for attr in ["orientation", "x", "y", "z", "x2", "y2", "z2"]:
+            value = getattr(self, attr)
+            if value is None:
+                setattr(self, attr, 0)
+
         root = et.Element(
             self.__class__.__name__.capitalize(),
             {

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/magnetic.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/magnetic.py
@@ -40,8 +40,10 @@ class Magnetic(Base):
         :rtype: TYPE
 
         """
-        if self.orientation is None:
-            self.orientation = 0
+        for attr in ["orientation", "x", "y", "z"]:
+            value = getattr(self, attr)
+            if value is None:
+                setattr(self, attr, 0)
         root = et.Element(
             self.__class__.__name__.capitalize(),
             {


### PR DESCRIPTION
If `EMTFXML.Electric` or `EMTFXML.Magnetic` attributes are None and they should be a float a Error is raised. This pull request fixes that.

- Update channels to set value to 0 if value is None. 