### PR TITLE
Changes to support writing z-files with channel_nomenclature

### DIFF
--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -70,6 +70,7 @@ class TF:
         # set metadata for the station
         self._survey_metadata = self._initialize_metadata()
         self.channel_nomenclature = DEFAULT_CHANNEL_NOMENCLATURE
+        self._inverse_channel_nomenclature = {}
 
         self._rotation_angle = 0
         self.save_dir = Path.cwd()
@@ -108,6 +109,12 @@ class TF:
 
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    @property
+    def inverse_channel_nomenclature(self):
+        if not self._inverse_channel_nomenclature:
+            self._inverse_channel_nomenclature = {v: k for k, v in self.channel_nomenclature.items()}
+        return self._inverse_channel_nomenclature
 
     def __str__(self):
         lines = [f"Station: {self.station}", "-" * 50]
@@ -2090,10 +2097,13 @@ class TF:
         >>> zmm_object.write()
 
         """
-        try:
-            zmm_obj = ZMM(decimation_dict=self.decimation_dict)
-        except AttributeError:
-            zmm_obj = ZMM()
+        zmm_kwargs = {}
+        zmm_kwargs["channel_nomenclature"] = self.channel_nomenclature
+        zmm_kwargs["inverse_channel_nomenclature"] = self.inverse_channel_nomenclature
+        if hasattr(self, "decimation_dict"):
+            zmm_kwargs["decimation_dict"] = self.decimation_dict
+        zmm_obj = ZMM(**zmm_kwargs)
+
         zmm_obj.dataset = self.dataset
         zmm_obj.station_metadata = self.station_metadata
 
@@ -2123,9 +2133,11 @@ class TF:
             for comp in self.station_metadata.runs[0].channels_recorded_all:
                 if "rr" in comp:
                     continue
-                ch = getattr(self.station_metadata.runs[0], comp)
+                ch = self.station_metadata.runs[0].get_channel(comp)
+                ch.component = self.inverse_channel_nomenclature[comp]
                 c = ZChannel()
                 c.from_dict(ch.to_dict(single=True))
+                ch.component = comp
                 try:
                     c.number = number_dict[c.channel]
                     setattr(zmm_obj, c.channel, c)

--- a/mt_metadata/transfer_functions/io/zfiles/zmm.py
+++ b/mt_metadata/transfer_functions/io/zfiles/zmm.py
@@ -296,6 +296,7 @@ class ZMM(ZMMHeader):
         self.periods = None
         self.dataset = None
         self.decimation_dict = {}
+        self.channel_nomenclature = {}
 
         self._ch_input_dict = {
             "impedance": ["hx", "hy"],
@@ -572,8 +573,10 @@ class ZMM(ZMMHeader):
             for c_out in self.output_channels:
                 line = ""
                 for c_in in self.input_channels:
+                    c_in_name = self.channel_nomenclature[c_in]
+                    c_out_name = self.channel_nomenclature[c_out]
                     tf_element = a.transfer_function.loc[
-                        dict(output=c_out, input=c_in)
+                        dict(output=c_out_name, input=c_in_name)
                     ].data
                     line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
                 lines += [line]
@@ -582,8 +585,10 @@ class ZMM(ZMMHeader):
             for ii, c_out in enumerate(self.input_channels):
                 line = ""
                 for c_in in self.input_channels[: ii + 1]:
+                    c_in_name = self.channel_nomenclature[c_in]
+                    c_out_name = self.channel_nomenclature[c_out]
                     tf_element = a.inverse_signal_power.loc[
-                        dict(output=c_out, input=c_in)
+                        dict(output=c_out_name, input=c_in_name)
                     ].data
                     line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
                 lines += [line]
@@ -592,8 +597,10 @@ class ZMM(ZMMHeader):
             for ii, c_out in enumerate(self.output_channels):
                 line = ""
                 for c_in in self.output_channels[: ii + 1]:
+                    c_in_name = self.channel_nomenclature[c_in]
+                    c_out_name = self.channel_nomenclature[c_out]
                     tf_element = a.residual_covariance.loc[
-                        dict(output=c_out, input=c_in)
+                        dict(output=c_out_name, input=c_in_name)
                     ].data
                     line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
                 lines += [line]


### PR DESCRIPTION
- Modify ZMM so that it has a channel_nomenclature property, default={}, it is set via kwargs
- modify tf value-setting for Z file to use channel_nomenclature mapping
- added inverse_channel_nomenclature to TF core, which provides reverse lookup for channel nomenclature
- intialize ZMM with kwargs, including channel_nomenclature, and decimations_dict

- Specific workaround in core.py: In core.py to_zmm() method, accessing channel via
ch = getattr(self.station_metadata.runs[0], comp)
didn't work when using LEMI channel nomenclature however using get_channel() worked. ch = self.station_metadata.runs[0].get_channel(comp)

However, then I couldn't call to_dict:
ch.to_dict() # fails
But it did work if I first overwrite the channel name ch.component = self.inverse_channel_nomenclature[comp] ch.to_dict() # works

The rest of z file writing goes fine, but the emtfxml fails (because I changed the componenet name) Solution was to revert the channel name after building ZChannel() from ch.to_dict() and then write it back.
ch.component = comp