### PR TITLE
Add optional usage of fortranformat strings

### DIFF
--- a/mt_metadata/transfer_functions/io/zfiles/zmm.py
+++ b/mt_metadata/transfer_functions/io/zfiles/zmm.py
@@ -544,6 +544,17 @@ class ZMM(ZMMHeader):
             * n_points, value = int
             * sampling_freq, value = float
         """
+        def format_line(line, tf_element):
+            try:
+                import fortranformat as ff
+                data_format = ff.FortranRecordWriter("(16E12.4)")
+                line += f"{data_format.write([tf_element.real])}"
+                line += f"{data_format.write([tf_element.imag])}"
+            except ImportError:
+                line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
+            return line
+
+
         if fn is not None:
             self.fn = fn
         lines = self.write_header()
@@ -579,7 +590,7 @@ class ZMM(ZMMHeader):
                     tf_element = a.transfer_function.loc[
                         dict(output=c_out_name, input=c_in_name)
                     ].data
-                    line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
+                    line = format_line(line, tf_element)
                 lines += [line]
             # write signal power
             lines += [" Inverse Coherent Signal Power Matrix"]
@@ -591,7 +602,7 @@ class ZMM(ZMMHeader):
                     tf_element = a.inverse_signal_power.loc[
                         dict(output=c_out_name, input=c_in_name)
                     ].data
-                    line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
+                    line = format_line(line, tf_element)
                 lines += [line]
             # write residual covariance
             lines += [" Residual Covariance"]
@@ -603,7 +614,7 @@ class ZMM(ZMMHeader):
                     tf_element = a.residual_covariance.loc[
                         dict(output=c_out_name, input=c_in_name)
                     ].data
-                    line += f"{tf_element.real:>12.4E}{tf_element.imag:>12.4E}"
+                    line = format_line(line, tf_element)
                 lines += [line]
         with open(self.fn, "w") as fid:
             fid.write("\n".join(lines))


### PR DESCRIPTION
In the old emtf z file, TF numbers were formatted with 0 in the first position. In the TF output the first position is non-zero, it is standard scientific notation.

This commit shows how to get the leading zero output if you have pip-installed fortran_format package. 

Deviation from standard scientific notation is relatively rare. The only related post I found re how to do this in python  was also about comparing strings from a fortran program.
https://stackoverflow.com/questions/21266850/python-scientific-notation-with-forced-leading-zero