### PR TITLE
Bug fix in FC layer

### DIFF
--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -320,7 +320,7 @@ class Decimation(Base):
         else:
             required_channels = decimation_level.local_channels
         try:
-            assert set(self.channels_estimated) == set(required_channels)
+            assert set(required_channels).issubset(self.channels_estimated)
         except AssertionError:
             msg = (
                 f"required_channels for processing {required_channels} not available"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -122,7 +122,7 @@ class TestBase(unittest.TestCase):
         self.assertEqual(other, new)
 
     def test_equal_other(self):
-        self.base_object == self.base_object.to_dict()["base"]
+        assert (self.base_object == self.base_object.to_dict()["base"])
 
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -124,6 +124,10 @@ class TestBase(unittest.TestCase):
     def test_equal_other(self):
         assert (self.base_object == self.base_object.to_dict()["base"])
 
+    def test_equal_str(self):
+        self.assertFalse(self.base_object == "None")
+
+
 
 
 # =============================================================================

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,7 @@ Tests for Metadata module
 
 .. todo::
     * write tests for to/from_xml
-    
+
 
 Created on Tue Apr 28 18:08:40 2020
 
@@ -120,6 +120,10 @@ class TestBase(unittest.TestCase):
 
         new = other.copy()
         self.assertEqual(other, new)
+
+    def test_equal_other(self):
+        self.base_object == self.base_object.to_dict()["base"]
+
 
 
 # =============================================================================


### PR DESCRIPTION
- was checking if required channels for processing _equal_ the set of available channels in the FC layer.
- this is incorrect, we should be checking if required channels are a subset of the available channels
- this bug was found when using fc layers for RR processing
- in that case, we only needed [hx, hy,], but an error was being thrown because the channels were [ex, ey, hx, hy, hz]