### PR TITLE
Updating git clone address in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Most people will be using the transfer functions, but a lot of that metadata com
 
 ## From Source
 
-`git clone git://github.com/kujaku11/mt_metadata`
+`git clone https://github.com/kujaku11/mt_metadata.git`
 
 `python setup.py install`
 


### PR DESCRIPTION
I believe the address for the `git clone` is not supported anymore.

```
$git clone git://github.com/kujaku11/mt_metadata
Cloning into 'mt_metadata'...
fatal: unable to connect to github.com:
github.com[0: 192.30.255.113]: errno=Resource temporarily unavailable
```
I tested https (`https://github.com/kujaku11/mt_metadata.git`) and ssh (`git@github.com:kujaku11/mt_metadata.git`) addresses, both work:
```
$git clone https://github.com/kujaku11/mt_metadata.git
Cloning into 'mt_metadata'...
remote: Enumerating objects: 12967, done.
remote: Counting objects: 100% (2484/2484), done.
remote: Compressing objects: 100% (665/665), done.
remote: Total 12967 (delta 1911), reused 2337 (delta 1817), pack-reused 10483
Receiving objects: 100% (12967/12967), 41.62 MiB | 16.27 MiB/s, done.
Resolving deltas: 100% (10010/10010), done.
```

I suggests updating the readme (and the PyPI landing page).