### PR TITLE
Change default value of `get_elevation` to False

### DIFF
--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -1777,7 +1777,7 @@ class TF:
     def read_tf_file(self, **kwargs):
         self.logger.error("'read_tf_file' has been deprecated use 'read()'")
 
-    def read(self, fn=None, file_type=None, get_elevation=True, **kwargs):
+    def read(self, fn=None, file_type=None, get_elevation=False, **kwargs):
         """
 
         Read an TF response file.
@@ -1883,7 +1883,7 @@ class TF:
 
         return edi_obj
 
-    def from_edi(self, edi_obj, get_elevation=True, **kwargs):
+    def from_edi(self, edi_obj, get_elevation=False, **kwargs):
         """
         Read in an EDI file or a
         :class:`mt_metadata.transfer_functions.io.edi.EDI` ojbect
@@ -2001,7 +2001,7 @@ class TF:
 
         return emtf
 
-    def from_emtfxml(self, emtfxml_obj, get_elevation=True, **kwargs):
+    def from_emtfxml(self, emtfxml_obj, get_elevation=False, **kwargs):
         """
 
         :param emtfxml_object: path to emtf xml file or EMTFXML object
@@ -2059,7 +2059,7 @@ class TF:
 
         raise IOError("to_jfile not implemented yet.")
 
-    def from_jfile(self, j_obj, get_elevation=True, **kwargs):
+    def from_jfile(self, j_obj, get_elevation=False, **kwargs):
         """
 
         :param jfile_obj: path ot .j file or JFile object
@@ -2192,7 +2192,7 @@ class TF:
 
         return zmm_obj
 
-    def from_zmm(self, zmm_obj, get_elevation=True, **kwargs):
+    def from_zmm(self, zmm_obj, get_elevation=False, **kwargs):
         """
 
         :param zmm_obj: path ot .zmm file or ZMM object
@@ -2261,7 +2261,7 @@ class TF:
         """
         return self.to_zmm()
 
-    def from_zrr(self, zrr_obj, get_elevation=True, **kwargs):
+    def from_zrr(self, zrr_obj, get_elevation=False, **kwargs):
         """
 
         :param zmm_obj: path ot .zmm file or ZMM object
@@ -2296,7 +2296,7 @@ class TF:
         """
         return self.to_zmm()
 
-    def from_zss(self, zss_obj, get_elevation=True, **kwargs):
+    def from_zss(self, zss_obj, get_elevation=False, **kwargs):
         """
 
         :param zmm_obj: path to .zmm file or ZMM object
@@ -2327,7 +2327,7 @@ class TF:
 
         raise AttributeError("to_avg does not exist yet.")
 
-    def from_avg(self, avg_obj, get_elevation=True, **kwargs):
+    def from_avg(self, avg_obj, get_elevation=False, **kwargs):
         """
 
         :param avg_obj: path to .avg file or ZongeMTAvg object

--- a/mt_metadata/transfer_functions/io/edi/edi.py
+++ b/mt_metadata/transfer_functions/io/edi/edi.py
@@ -252,7 +252,7 @@ class EDI(object):
             return 1.0 / self.frequency
         return None
 
-    def read(self, fn=None, get_elevation=True):
+    def read(self, fn=None, get_elevation=False):
         """
         Read in an edi file and fill attributes of each section's classes.
         Including:
@@ -419,7 +419,8 @@ class EDI(object):
                         )
                 elif key.startswith("t"):
                     obj[:, ii, jj] = (
-                        data_dict[f"{key}r.exp"] + data_dict[f"{key}i.exp"] * 1j
+                        data_dict[f"{key}r.exp"]
+                        + data_dict[f"{key}i.exp"] * 1j
                     )
                     try:
                         error_key = [
@@ -672,7 +673,7 @@ class EDI(object):
                 + np.matmul(tf, np.matmul(hh, tfh))
             ) / avgt_dict[key]
 
-            #variance = abs(np.dot(res[0 : cc.n_inputs, :].T, sig))
+            # variance = abs(np.dot(res[0 : cc.n_inputs, :].T, sig))
             variance = np.zeros((cc.n_outputs, cc.n_inputs), dtype=complex)
             for nn in range(cc.n_outputs):
                 for mm in range(cc.n_inputs):
@@ -756,7 +757,9 @@ class EDI(object):
                 f"\toriginal_program.date={self.Header.progdate}\n"
             )
         if self.Header.fileby != "1980-01-01":
-            extra_lines.append(f"\toriginal_file.date={self.Header.filedate}\n")
+            extra_lines.append(
+                f"\toriginal_file.date={self.Header.filedate}\n"
+            )
         header_lines = self.Header.write_header(
             longitude_format=longitude_format, latlon_format=latlon_format
         )
@@ -904,11 +907,15 @@ class EDI(object):
             ]
         elif data_key.lower() == "freq":
             block_lines = [
-                ">{0} // {1:.0f}\n".format(data_key.upper(), data_comp_arr.size)
+                ">{0} // {1:.0f}\n".format(
+                    data_key.upper(), data_comp_arr.size
+                )
             ]
         elif data_key.lower() in ["zrot", "trot"]:
             block_lines = [
-                ">{0} // {1:.0f}\n".format(data_key.upper(), data_comp_arr.size)
+                ">{0} // {1:.0f}\n".format(
+                    data_key.upper(), data_comp_arr.size
+                )
             ]
         else:
             raise ValueError("Cannot write block for {0}".format(data_key))

--- a/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
@@ -273,7 +273,7 @@ class EMTFXML(emtf_xml.EMTF):
             return self.fn.parent
         return None
 
-    def read(self, fn=None, get_elevation=True):
+    def read(self, fn=None, get_elevation=False):
         """
         Read xml file
 
@@ -377,7 +377,6 @@ class EMTFXML(emtf_xml.EMTF):
                         emtf_helpers._convert_tag_to_capwords(element)
                     )
             else:
-
                 emtf_helpers._write_single(
                     emtf_element, key, getattr(self, key)
                 )
@@ -654,7 +653,6 @@ class EMTFXML(emtf_xml.EMTF):
                 value,
             )
         elif fkey in ["x", "y", "z"]:
-
             if comp in ["hx", "hy"]:
                 if len(self.site_layout.output_channels) == 0:
                     self.site_layout.input_channels.append(
@@ -1231,7 +1229,6 @@ class EMTFXML(emtf_xml.EMTF):
                                 )
                                 self.logger.exception(error)
                         else:
-
                             try:
                                 run.set_attr_from_name(key, value)
                             except Exception as error:

--- a/mt_metadata/transfer_functions/io/jfiles/jfile.py
+++ b/mt_metadata/transfer_functions/io/jfiles/jfile.py
@@ -23,6 +23,7 @@ from mt_metadata.utils.mttime import MTime
 from .metadata import Header
 from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
+
 # ==============================================================================
 # Class to read j_file
 # ==============================================================================
@@ -161,7 +162,7 @@ class JFile:
 
         return j_lines
 
-    def read(self, fn=None, get_elevation=True):
+    def read(self, fn=None, get_elevation=False):
         """
         Read data from a j file
 

--- a/mt_metadata/transfer_functions/io/zfiles/zmm.py
+++ b/mt_metadata/transfer_functions/io/zfiles/zmm.py
@@ -40,7 +40,6 @@ class ZMMHeader(object):
     """
 
     def __init__(self, fn=None, **kwargs):
-
         self.logger = logger
         self.processing_type = None
         self.num_channels = None
@@ -293,7 +292,6 @@ class ZMM(ZMMHeader):
     """
 
     def __init__(self, fn=None, **kwargs):
-
         super().__init__()
 
         self.fn = fn
@@ -464,7 +462,7 @@ class ZMM(ZMMHeader):
         #    this dimension is hard-coded
         self.sigma_s = np.zeros((self.num_freq, 2, 2), dtype=np.complex64)
 
-    def read(self, fn=None, get_elevation=True):
+    def read(self, fn=None, get_elevation=False):
         """
         Read in Egbert zrr/zmm file
 

--- a/mt_metadata/transfer_functions/io/zonge/zonge.py
+++ b/mt_metadata/transfer_functions/io/zonge/zonge.py
@@ -28,6 +28,7 @@ from mt_metadata.transfer_functions.tf import (
 )
 from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
+
 # ==============================================================================
 # deal with avg files output from mtedit
 # ==============================================================================
@@ -37,7 +38,6 @@ class ZongeMTAvg:
     """
 
     def __init__(self, fn=None, **kwargs):
-
         self.logger = logger
         self.header = Header()
 
@@ -122,7 +122,7 @@ class ZongeMTAvg:
         else:
             self._fn = None
 
-    def read(self, fn=None, get_elevation=True):
+    def read(self, fn=None, get_elevation=False):
         """
         Read into a pandas data frame
 

--- a/tests/tf/io/edi/test_edi_spectra.py
+++ b/tests/tf/io/edi/test_edi_spectra.py
@@ -16,7 +16,7 @@ from mt_metadata.transfer_functions.io.edi import EDI
 from mt_metadata.utils.mttime import MTime
 from mt_metadata import TF_EDI_SPECTRA, TF_EDI_SPECTRA_OUT
 from mt_metadata.transfer_functions import TF
-from mt_metadata.transfer_functions.io.tools import get_nm_elev
+
 
 # =============================================================================
 # CGG
@@ -34,7 +34,7 @@ class TestSpectraEDI(unittest.TestCase):
             "COORDINATE_SYSTEM": "geographic",
             "DATAID": "SAGE_2005_og",
             "DATUM": "WGS84",
-            "ELEV": get_nm_elev(35.55, -106.28333333333333),
+            "ELEV": 0,
             "EMPTY": 1e32,
             "FILEBY": "Quantec Consulting",
             "LAT": 35.55,
@@ -198,7 +198,9 @@ class TestSpectraEDI(unittest.TestCase):
             )
 
         with self.subTest("refelev"):
-            self.assertAlmostEqual(0.0, self.edi_spectra.Measurement.refelev, 2)
+            self.assertAlmostEqual(
+                0.0, self.edi_spectra.Measurement.refelev, 2
+            )
 
     def test_data_section(self):
         d_list = [

--- a/tests/tf/io/zmm/test_tf_read_zmm.py
+++ b/tests/tf/io/zmm/test_tf_read_zmm.py
@@ -14,7 +14,6 @@ import numpy as np
 from collections import OrderedDict
 from mt_metadata import TF_ZMM
 from mt_metadata.transfer_functions import TF
-from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
 # =============================================================================
 # EMTFXML
@@ -65,7 +64,7 @@ class TestZMM(unittest.TestCase):
                 ("id", "300"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 13.1),
-                ("location.elevation", get_nm_elev(34.727, -115.735)),
+                ("location.elevation", 0),
                 ("location.latitude", 34.727),
                 ("location.longitude", -115.735),
                 ("orientation.method", None),
@@ -273,7 +272,9 @@ class TestZMM(unittest.TestCase):
 
     def test_residual(self):
         with self.subTest(msg="shape"):
-            self.assertTupleEqual((38, 3, 3), self.tf.residual_covariance.shape)
+            self.assertTupleEqual(
+                (38, 3, 3), self.tf.residual_covariance.shape
+            )
 
         with self.subTest("has residual_covariance"):
             self.assertTrue(self.tf.has_residual_covariance())
@@ -377,7 +378,7 @@ class TestTFToEMTFXML(unittest.TestCase):
                 ("id", "300"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 13.1),
-                ("location.elevation", get_nm_elev(34.727, -115.735)),
+                ("location.elevation", 0),
                 ("location.latitude", 34.727),
                 ("location.longitude", -115.735),
                 ("orientation.method", None),

--- a/tests/tf/io/zmm/test_tf_read_zss.py
+++ b/tests/tf/io/zmm/test_tf_read_zss.py
@@ -14,7 +14,6 @@ import numpy as np
 from collections import OrderedDict
 from mt_metadata import TF_ZSS_TIPPER
 from mt_metadata.transfer_functions import TF
-from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
 # =============================================================================
 # EMTFXML
@@ -65,7 +64,7 @@ class TestZSS(unittest.TestCase):
                 ("id", "YSW212abcdefghijkl"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 11.18),
-                ("location.elevation", get_nm_elev(44.631, -110.44)),
+                ("location.elevation", 0),
                 ("location.latitude", 44.631),
                 ("location.longitude", -110.44),
                 ("orientation.method", None),
@@ -143,7 +142,9 @@ class TestZSS(unittest.TestCase):
             self.assertTrue(
                 np.isclose(
                     self.tf.tipper[0],
-                    np.array([[-0.20389999 + 0.09208j, 0.05996000 + 0.03177j]]),
+                    np.array(
+                        [[-0.20389999 + 0.09208j, 0.05996000 + 0.03177j]]
+                    ),
                 ).all()
             )
         with self.subTest(msg="last element"):
@@ -196,7 +197,9 @@ class TestZSS(unittest.TestCase):
 
     def test_residual(self):
         with self.subTest(msg="shape"):
-            self.assertTupleEqual((44, 3, 3), self.tf.residual_covariance.shape)
+            self.assertTupleEqual(
+                (44, 3, 3), self.tf.residual_covariance.shape
+            )
         with self.subTest("has residual_covariance"):
             self.assertTrue(self.tf.has_residual_covariance())
         with self.subTest(msg="first element"):

--- a/tests/tf/io/zonge/test_tf_read.py
+++ b/tests/tf/io/zonge/test_tf_read.py
@@ -14,7 +14,6 @@ import numpy as np
 from collections import OrderedDict
 from mt_metadata import TF_AVG
 from mt_metadata.transfer_functions import TF
-from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
 # =============================================================================
 # EMTFXML

--- a/tests/tf/io/zonge/test_tf_read.py
+++ b/tests/tf/io/zonge/test_tf_read.py
@@ -65,10 +65,7 @@ class TestAVG(unittest.TestCase):
                 ("location.datum", "WGS84"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 0.0),
-                (
-                    "location.elevation",
-                    get_nm_elev(32.83331167, -107.08305667),
-                ),
+                ("location.elevation", 0),
                 ("location.latitude", 32.83331167),
                 ("location.longitude", -107.08305667),
                 ("orientation.method", None),

--- a/tests/tf/io/zonge/test_tf_read_newer.py
+++ b/tests/tf/io/zonge/test_tf_read_newer.py
@@ -14,7 +14,6 @@ import numpy as np
 from collections import OrderedDict
 from mt_metadata import TF_AVG_NEWER
 from mt_metadata.transfer_functions import TF
-from mt_metadata.transfer_functions.io.tools import get_nm_elev
 
 # =============================================================================
 # EMTFXML
@@ -65,7 +64,7 @@ class TestReadAVGNewer(unittest.TestCase):
                 ("location.datum", "WGS84"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 0.0),
-                ("location.elevation", get_nm_elev(44.1479163, -111.0497517)),
+                ("location.elevation", 0),
                 ("location.latitude", 44.1479163),
                 ("location.longitude", -111.0497517),
                 ("orientation.method", None),


### PR DESCRIPTION
In theory this is a good idea, but in practice it is costly and slow.  Change the default value to `False` when reading in a transfer function.  The user then has the option to look up elevation if they want.  