### PR TITLE
Adjust how TF._initialize_transfer_function is setup

### DIFF
--- a/mt_metadata/__init__.py
+++ b/mt_metadata/__init__.py
@@ -82,6 +82,14 @@ REQUIRED_KEYS = [
     "default",
 ]
 
+DEFAULT_CHANNEL_NOMENCLATURE = {
+    "hx": "hx",
+    "hy": "hy",
+    "hz": "hz",
+    "ex": "ex",
+    "ey": "ey",
+}
+
 # =============================================================================
 # Initiate loggers
 # =============================================================================
@@ -152,19 +160,13 @@ TF_POOR_XML = DATA_DIR.joinpath("data/transfer_functions/tf_poor_xml.xml")
 TF_XML_MULTIPLE_ATTACHMENTS = DATA_DIR.joinpath(
     "data/transfer_functions/tf_xml_multiple_attachments.xml"
 )
-TF_EDI_PHOENIX = DATA_DIR.joinpath(
-    "data/transfer_functions/tf_edi_phoenix.edi"
-)
-TF_EDI_EMPOWER = DATA_DIR.joinpath(
-    "data/transfer_functions/tf_edi_empower.edi"
-)
+TF_EDI_PHOENIX = DATA_DIR.joinpath("data/transfer_functions/tf_edi_phoenix.edi")
+TF_EDI_EMPOWER = DATA_DIR.joinpath("data/transfer_functions/tf_edi_empower.edi")
 TF_EDI_METRONIX = DATA_DIR.joinpath(
     "data/transfer_functions/tf_edi_metronix.edi"
 )
 TF_EDI_CGG = DATA_DIR.joinpath("data/transfer_functions/tf_edi_cgg.edi")
-TF_EDI_QUANTEC = DATA_DIR.joinpath(
-    "data/transfer_functions/tf_edi_quantec.edi"
-)
+TF_EDI_QUANTEC = DATA_DIR.joinpath("data/transfer_functions/tf_edi_quantec.edi")
 TF_EDI_RHO_ONLY = DATA_DIR.joinpath(
     "data/transfer_functions/tf_edi_rho_only.edi"
 )

--- a/mt_metadata/data/transfer_functions/tf_zmm.zmm
+++ b/mt_metadata/data/transfer_functions/tf_zmm.zmm
@@ -1,5 +1,5 @@
  TRANSFER FUNCTIONS IN MEASUREMENT COORDINATES
- ********** WITH FULL ERROR COVARINCE*********
+ ********** WITH FULL ERROR COVARIANCE*********
                                                                                 
 300                 
 coordinate    34.727  -115.735 declination    13.10

--- a/mt_metadata/transfer_functions/__init__.py
+++ b/mt_metadata/transfer_functions/__init__.py
@@ -1,11 +1,3 @@
 from .core import TF
 
 __all__ = ["TF"]
-
-DEFAULT_CHANNEL_NOMENCLATURE = {
-    "hx": "hx",
-    "hy": "hy",
-    "hz": "hz",
-    "ex": "ex",
-    "ey": "ey",
-}

--- a/mt_metadata/transfer_functions/__init__.py
+++ b/mt_metadata/transfer_functions/__init__.py
@@ -1,3 +1,11 @@
 from .core import TF
 
 __all__ = ["TF"]
+
+DEFAULT_CHANNEL_NOMENCLATURE = {
+    "hx": "hx",
+    "hy": "hy",
+    "hz": "hz",
+    "ex": "ex",
+    "ey": "ey",
+}

--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -36,7 +36,7 @@ from mt_metadata.transfer_functions.io.zfiles.metadata import (
 )
 from mt_metadata.base.helpers import validate_name
 from mt_metadata.utils.list_dict import ListDict
-from mt_metadata.transfer_functions import DEFAULT_CHANNEL_NOMENCLATURE
+from mt_metadata import DEFAULT_CHANNEL_NOMENCLATURE
 
 # =============================================================================
 

--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -36,14 +36,8 @@ from mt_metadata.transfer_functions.io.zfiles.metadata import (
 )
 from mt_metadata.base.helpers import validate_name
 from mt_metadata.utils.list_dict import ListDict
+from mt_metadata.transfer_functions import DEFAULT_CHANNEL_NOMENCLATURE
 
-DEFAULT_CHANNEL_NOMENCLATURE = {
-    "hx": "hx",
-    "hy": "hy",
-    "hz": "hz",
-    "ex": "ex",
-    "ey": "ey",
-}
 # =============================================================================
 
 

--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -197,10 +197,7 @@ class TF:
             self.logger.info("Survey Metadata is not equal")
             is_equal = False
         if self.has_transfer_function() and other.has_transfer_function():
-            if (
-                self.transfer_function.fillna(0)
-                != other.transfer_function.fillna(0)
-            ).any():
+            if not self.transfer_function.equals(other.transfer_function):
                 self.logger.info("TF is not equal")
                 is_equal = False
         elif (
@@ -383,9 +380,7 @@ class TF:
         """
 
         if station_metadata is not None:
-            station_metadata = self._validate_station_metadata(
-                station_metadata
-            )
+            station_metadata = self._validate_station_metadata(station_metadata)
 
             runs = ListDict()
             if self.run_metadata.id not in ["0", 0, None]:
@@ -455,56 +450,56 @@ class TF:
         """
         # create an empty array for the transfer function
         tf = xr.DataArray(
-            data=0 + 0j,
+            data=0.0 + 0j,
             dims=["period", "output", "input"],
             coords={
                 "period": periods,
-                "output": self._ch_output_dict["tf"],
-                "input": self._ch_input_dict["tf"],
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
             },
             name="transfer_function",
         )
 
         tf_err = xr.DataArray(
-            data=0,
+            data=0.0,
             dims=["period", "output", "input"],
             coords={
                 "period": periods,
-                "output": self._ch_output_dict["tf"],
-                "input": self._ch_input_dict["tf"],
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
             },
             name="transfer_function_error",
         )
 
         tf_model_err = xr.DataArray(
-            data=0,
+            data=0.0,
             dims=["period", "output", "input"],
             coords={
                 "period": periods,
-                "output": self._ch_output_dict["tf"],
-                "input": self._ch_input_dict["tf"],
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
             },
             name="transfer_function_model_error",
         )
 
         inv_signal_power = xr.DataArray(
-            data=0 + 0j,
+            data=0.0 + 0j,
             dims=["period", "output", "input"],
             coords={
                 "period": periods,
-                "output": self._ch_output_dict["isp"],
-                "input": self._ch_input_dict["isp"],
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
             },
             name="inverse_signal_power",
         )
 
         residual_covariance = xr.DataArray(
-            data=0 + 0j,
+            data=0.0 + 0j,
             dims=["period", "output", "input"],
             coords={
                 "period": periods,
-                "output": self._ch_output_dict["res"],
-                "input": self._ch_input_dict["res"],
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
             },
             name="residual_covariance",
         )
@@ -517,7 +512,12 @@ class TF:
                 tf_model_err.name: tf_model_err,
                 inv_signal_power.name: inv_signal_power,
                 residual_covariance.name: residual_covariance,
-            }
+            },
+            coords={
+                "period": periods,
+                "output": self._ch_output_dict["all"],
+                "input": self._ch_input_dict["all"],
+            },
         )
 
     # ==========================================================================
@@ -563,6 +563,7 @@ class TF:
             "res": self.ex_ey_hz,
             "tf": self.hx_hy,
             "tf_error": self.hx_hy,
+            "all": [self.ex, self.ey, self.hz, self.hx, self.hy],
         }
 
     @property
@@ -578,6 +579,7 @@ class TF:
             "res": self.ex_ey_hz,
             "tf": self.ex_ey_hz,
             "tf_error": self.ex_ey_hz,
+            "all": [self.ex, self.ey, self.hz, self.hx, self.hy],
         }
 
     @property

--- a/mt_metadata/transfer_functions/io/zfiles/zmm.py
+++ b/mt_metadata/transfer_functions/io/zfiles/zmm.py
@@ -25,6 +25,7 @@ from mt_metadata.transfer_functions.tf import (
 from mt_metadata.transfer_functions.io.tools import get_nm_elev
 from .metadata import Channel
 from mt_metadata.utils.list_dict import ListDict
+from mt_metadata.transfer_functions import DEFAULT_CHANNEL_NOMENCLATURE
 
 # ==============================================================================
 PERIOD_FORMAT = ".10g"
@@ -300,13 +301,7 @@ class ZMM(ZMMHeader):
         self.periods = None
         self.dataset = None
         self.decimation_dict = {}
-        self.channel_nomenclature = {
-            "hx": "hx",
-            "hy": "hy",
-            "hz": "hz",
-            "ex": "ex",
-            "ey": "ey",
-        }
+        self.channel_nomenclature = DEFAULT_CHANNEL_NOMENCLATURE
 
         self._ch_input_dict = {
             "impedance": ["hx", "hy"],
@@ -393,6 +388,33 @@ class ZMM(ZMMHeader):
             self.logger.info("Datasets are not equal")
             print(self.dataset.fillna(0) != other.dataset.fillna(0).all())
         return is_equal
+
+    @property
+    def channel_nomenclature(self):
+        return self._channel_nomenclature
+
+    @channel_nomenclature.setter
+    def channel_nomenclature(self, ch_dict):
+        """
+        channel dictionary
+        """
+
+        if not isinstance(ch_dict, dict):
+            raise TypeError(
+                "Channel_nomenclature must be a dictionary with keys "
+                "['ex', 'ey', 'hx', 'hy', 'hz']."
+            )
+
+        self._channel_nomenclature = ch_dict
+        # unpack channel nomenclature dict
+        self.ex = self._channel_nomenclature["ex"]
+        self.ey = self._channel_nomenclature["ey"]
+        self.hx = self._channel_nomenclature["hx"]
+        self.hy = self._channel_nomenclature["hy"]
+        self.hz = self._channel_nomenclature["hz"]
+        self.ex_ey = [self.ex, self.ey]
+        self.hx_hy = [self.hx, self.hy]
+        self.ex_ey_hz = [self.ex, self.ey, self.hz]
 
     def _initialize_transfer_function(self, periods=[1]):
         """

--- a/mt_metadata/transfer_functions/io/zfiles/zmm.py
+++ b/mt_metadata/transfer_functions/io/zfiles/zmm.py
@@ -402,9 +402,10 @@ class ZMM(ZMMHeader):
         # unpack channel nomenclature dict
         for comp in DEFAULT_CHANNEL_NOMENCLATURE.keys():
             try:
-                setattr(self, f"_{comp}", self._channel_nomenclature[comp])
+                setattr(self, f"_{comp}", ch_dict[comp])
             except KeyError:
                 setattr(self, f"_{comp}", comp)
+                ch_dict[comp] = comp
 
         self._ex_ey = [self._ex, self._ey]
         self._hx_hy = [self._hx, self._hy]

--- a/tests/tf/io/zmm/test_tf_read_zmm.py
+++ b/tests/tf/io/zmm/test_tf_read_zmm.py
@@ -58,13 +58,13 @@ class TestZMM(unittest.TestCase):
         meta_dict = OrderedDict(
             [
                 ("channels_recorded", ["ex", "ey", "hx", "hy", "hz"]),
-                ("comments", "WITH FULL ERROR COVARINCE"),
+                ("comments", "WITH FULL ERROR COVARIANCE"),
                 ("data_type", "MT"),
                 ("geographic_name", None),
                 ("id", "300"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 13.1),
-                ("location.elevation", 0),
+                ("location.elevation", 0.0),
                 ("location.latitude", 34.727),
                 ("location.longitude", -115.735),
                 ("orientation.method", None),
@@ -238,10 +238,10 @@ class TestZMM(unittest.TestCase):
                         [
                             [
                                 18.05999947 - 4.46999991e-07j,
-                                -27.14999962 + 6.88899994e00j,
+                                -27.14999962 - 6.88899994e00j,
                             ],
                             [
-                                -27.14999962 - 6.88899994e00j,
+                                -27.14999962 + 6.88899994e00j,
                                 130.3999939 + 2.38400006e-07j,
                             ],
                         ]
@@ -258,7 +258,7 @@ class TestZMM(unittest.TestCase):
                         [
                             [
                                 1.92300007e-07 - 4.44100010e-16j,
-                                3.36799992e-08 - 1.40400003e-08j,
+                                3.36799992e-08 + 1.40400003e-08j,
                             ],
                             [
                                 3.36799992e-08 - 1.40400003e-08j,
@@ -272,9 +272,7 @@ class TestZMM(unittest.TestCase):
 
     def test_residual(self):
         with self.subTest(msg="shape"):
-            self.assertTupleEqual(
-                (38, 3, 3), self.tf.residual_covariance.shape
-            )
+            self.assertTupleEqual((38, 3, 3), self.tf.residual_covariance.shape)
 
         with self.subTest("has residual_covariance"):
             self.assertTrue(self.tf.has_residual_covariance())
@@ -372,13 +370,13 @@ class TestTFToEMTFXML(unittest.TestCase):
         meta_dict = OrderedDict(
             [
                 ("channels_recorded", ["ex", "ey", "hx", "hy", "hz"]),
-                ("comments", "WITH FULL ERROR COVARINCE"),
+                ("comments", "WITH FULL ERROR COVARIANCE"),
                 ("data_type", "MT"),
                 ("geographic_name", None),
                 ("id", "300"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 13.1),
-                ("location.elevation", 0),
+                ("location.elevation", 0.0),
                 ("location.latitude", 34.727),
                 ("location.longitude", -115.735),
                 ("orientation.method", None),

--- a/tests/tf/io/zmm/test_tf_read_zss.py
+++ b/tests/tf/io/zmm/test_tf_read_zss.py
@@ -64,7 +64,7 @@ class TestZSS(unittest.TestCase):
                 ("id", "YSW212abcdefghijkl"),
                 ("location.declination.model", "WMM"),
                 ("location.declination.value", 11.18),
-                ("location.elevation", 0),
+                ("location.elevation", 0.0),
                 ("location.latitude", 44.631),
                 ("location.longitude", -110.44),
                 ("orientation.method", None),
@@ -142,9 +142,7 @@ class TestZSS(unittest.TestCase):
             self.assertTrue(
                 np.isclose(
                     self.tf.tipper[0],
-                    np.array(
-                        [[-0.20389999 + 0.09208j, 0.05996000 + 0.03177j]]
-                    ),
+                    np.array([[-0.20389999 + 0.09208j, 0.05996000 + 0.03177j]]),
                 ).all()
             )
         with self.subTest(msg="last element"):
@@ -168,8 +166,8 @@ class TestZSS(unittest.TestCase):
                     self.tf.inverse_signal_power[0],
                     np.array(
                         [
-                            [136.19999695 + 0.0j, -9.60000038 - 5.32700014j],
-                            [-9.60000038 + 5.32700014j, 336.1000061 + 0.0j],
+                            [136.19999695 + 0.0j, -9.60000038 + 5.32700014j],
+                            [-9.60000038 - 5.32700014j, 336.1000061 + 0.0j],
                         ]
                     ),
                     atol=1e-5,
@@ -183,7 +181,7 @@ class TestZSS(unittest.TestCase):
                         [
                             [
                                 3.59999990e-06 + 0.00000000e00j,
-                                2.10999997e-06 - 9.44800007e-08j,
+                                2.10999997e-06 + 9.44800007e-08j,
                             ],
                             [
                                 2.10999997e-06 - 9.44800007e-08j,
@@ -197,9 +195,7 @@ class TestZSS(unittest.TestCase):
 
     def test_residual(self):
         with self.subTest(msg="shape"):
-            self.assertTupleEqual(
-                (44, 3, 3), self.tf.residual_covariance.shape
-            )
+            self.assertTupleEqual((44, 3, 3), self.tf.residual_covariance.shape)
         with self.subTest("has residual_covariance"):
             self.assertTrue(self.tf.has_residual_covariance())
         with self.subTest(msg="first element"):

--- a/tests/tf/io/zmm/test_zmm.py
+++ b/tests/tf/io/zmm/test_zmm.py
@@ -13,7 +13,7 @@ import pathlib
 
 from mt_metadata.transfer_functions import TF
 from mt_metadata.transfer_functions.io.zfiles import zmm
-from mt_metadata import TF_ZMM
+from mt_metadata import TF_ZMM, DEFAULT_CHANNEL_NOMENCLATURE
 
 # =============================================================================
 
@@ -38,6 +38,42 @@ class TestTranslateZmm(unittest.TestCase):
     def test_channels_recorded(self):
         self.assertListEqual(
             ["hx", "hy", "hz", "ex", "ey"], self.zmm_obj.channels_recorded
+        )
+
+    def test_channels_dict(self):
+        self.assertDictEqual(
+            {"hx": "hx", "hy": "hy", "hz": "hz", "ex": "ex", "ey": "ey"},
+            self.zmm_obj.channel_dict,
+        )
+
+    def test_channel_nomenclature(self):
+        self.assertDictEqual(
+            DEFAULT_CHANNEL_NOMENCLATURE,
+            self.zmm_obj.channel_nomenclature,
+        )
+
+    def test_ch_input_dict(self):
+        self.assertDictEqual(
+            {
+                "isp": ["hx", "hy"],
+                "res": ["ex", "ey", "hz"],
+                "tf": ["hx", "hy"],
+                "tf_error": ["hx", "hy"],
+                "all": ["ex", "ey", "hz", "hx", "hy"],
+            },
+            self.zmm_obj._ch_input_dict,
+        )
+
+    def test_ch_output_dict(self):
+        self.assertDictEqual(
+            {
+                "isp": ["hx", "hy"],
+                "res": ["ex", "ey", "hz"],
+                "tf": ["ex", "ey", "hz"],
+                "tf_error": ["ex", "ey", "hz"],
+                "all": ["ex", "ey", "hz", "hx", "hy"],
+            },
+            self.zmm_obj._ch_output_dict,
         )
 
     def test_channel_string(self):

--- a/tests/tf/io/zmm/test_zmm.py
+++ b/tests/tf/io/zmm/test_zmm.py
@@ -9,6 +9,7 @@ Created on Mon Sep 27 16:28:09 2021
 # =============================================================================
 import unittest
 import numpy as np
+import pathlib
 
 from mt_metadata.transfer_functions import TF
 from mt_metadata.transfer_functions.io.zfiles import zmm
@@ -55,6 +56,12 @@ class TestTranslateZmm(unittest.TestCase):
                 self.zmm_obj.ex.__repr__(),
                 to_str,
             )
+
+    def test_eq(self):
+        self.assertTrue(self.zmm_obj.__eq__(self.zmm_obj))
+
+    def test_not_equal(self):
+        self.assertRaises(TypeError, self.zmm_obj.__eq__, "a")
 
     def test_hx(self):
         with self.subTest("Testing Channel hx.channel", i=1):
@@ -159,6 +166,21 @@ class TestTranslateZmm(unittest.TestCase):
             else:
                 with self.subTest(zmm_key):
                     self.assertEqual(zmm_value, tf_st[zmm_key])
+
+    def test_write_read_write_zmm(self):
+        """
+        Have a zmm
+        Read it in, write it out.
+        Compare the output with the original
+        """
+        # import filecmp
+        out_file = pathlib.Path("test_output.zmm")
+        self.zmm_obj.write(out_file)
+        new_zmm_obj = zmm.ZMM(out_file)
+
+        self.assertEqual(self.zmm_obj, new_zmm_obj)
+        # assert filecmp.cmp(TF_ZMM, out_file)
+        out_file.unlink()
 
 
 # =============================================================================

--- a/tests/tf/io/zmm/test_zss.py
+++ b/tests/tf/io/zmm/test_zss.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from mt_metadata.transfer_functions import TF
 from mt_metadata.transfer_functions.io.zfiles import zmm
-from mt_metadata import TF_ZSS_TIPPER
+from mt_metadata import TF_ZSS_TIPPER, DEFAULT_CHANNEL_NOMENCLATURE
 
 # =============================================================================
 
@@ -36,6 +36,17 @@ class TestTranslateZmm(unittest.TestCase):
 
     def test_channels_recorded(self):
         self.assertListEqual(["hx", "hy", "hz"], self.zmm_obj.channels_recorded)
+
+    def test_channels_dict(self):
+        self.assertDictEqual(
+            {"hx": "hx", "hy": "hy", "hz": "hz"}, self.zmm_obj.channel_dict
+        )
+
+    def test_channel_nomenclature(self):
+        self.assertDictEqual(
+            DEFAULT_CHANNEL_NOMENCLATURE,
+            self.zmm_obj.channel_nomenclatureclature,
+        )
 
     def test_hx(self):
         with self.subTest("Testing Channel hx.channel", i=1):

--- a/tests/tf/io/zmm/test_zss.py
+++ b/tests/tf/io/zmm/test_zss.py
@@ -45,7 +45,31 @@ class TestTranslateZmm(unittest.TestCase):
     def test_channel_nomenclature(self):
         self.assertDictEqual(
             DEFAULT_CHANNEL_NOMENCLATURE,
-            self.zmm_obj.channel_nomenclatureclature,
+            self.zmm_obj.channel_nomenclature,
+        )
+
+    def test_ch_input_dict(self):
+        self.assertDictEqual(
+            {
+                "isp": ["hx", "hy"],
+                "res": ["ex", "ey", "hz"],
+                "tf": ["hx", "hy"],
+                "tf_error": ["hx", "hy"],
+                "all": ["ex", "ey", "hz", "hx", "hy"],
+            },
+            self.zmm_obj._ch_input_dict,
+        )
+
+    def test_ch_output_dict(self):
+        self.assertDictEqual(
+            {
+                "isp": ["hx", "hy"],
+                "res": ["ex", "ey", "hz"],
+                "tf": ["ex", "ey", "hz"],
+                "tf_error": ["ex", "ey", "hz"],
+                "all": ["ex", "ey", "hz", "hx", "hy"],
+            },
+            self.zmm_obj._ch_output_dict,
         )
 
     def test_hx(self):

--- a/tests/tf/test_core_tf.py
+++ b/tests/tf/test_core_tf.py
@@ -4,20 +4,90 @@ Created on Wed Sep 22 10:51:37 2021
 
 @author: jpeacock
 """
-
+# =============================================================================
+#
+# =============================================================================
 import unittest
 import xarray as xr
 import numpy as np
 
 from mt_metadata.transfer_functions.core import TF, TFError
 
+# =============================================================================
+
 
 class TestTFCore(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.tf = TF(some_kwarg=42)
-        print(self.tf)
-        print(self.tf.__repr__())
-        print(self.tf.__str__())
+
+    def test_str(self):
+        default_string = "\n".join(
+            [
+                "Station: 0",
+                "--------------------------------------------------",
+                "\tSurvey:            0",
+                "\tProject:           None",
+                "\tAcquired by:       None",
+                "\tAcquired date:     1980-01-01",
+                "\tLatitude:          0.000",
+                "\tLongitude:         0.000",
+                "\tElevation:         0.000",
+                "\tDeclination:   ",
+                "\t\tValue:     0.0",
+                "\t\tModel:     WMM",
+                "\tCoordinate System: geographic",
+                "\tImpedance:         False",
+                "\tTipper:            False",
+                "\tN Periods:     1",
+                "\tPeriod Range:",
+                "\t\tMin:   1.00000E+00 s",
+                "\t\tMax:   1.00000E+00 s",
+                "\tFrequency Range:",
+                "\t\tMin:   1.00000E+00 Hz",
+                "\t\tMax:   1.00000E+00 Hz",
+            ]
+        )
+        self.assertEqual(default_string, self.tf.__str__())
+
+    def test_repr(self):
+        default_string = "TF( survey='0', station='0', latitude=0.00, longitude=0.00, elevation=0.00 )"
+        self.assertEqual(default_string, self.tf.__repr__())
+
+    def test_empty_equals(self):
+        other_tf = TF()
+        self.assertEqual(self.tf, other_tf)
+
+
+class TestTFEqual(unittest.TestCase):
+    def setUp(self):
+        period = [0.1, 1, 10]
+        z = np.random.randn(3, 2, 2) + 1j * np.random.randn(3, 2, 2)
+        z_err = np.ones((3, 2, 2)) * 0.05
+        t = np.random.randn(3, 1, 2) + 1j * np.random.randn(3, 1, 2)
+        t_err = np.ones((3, 1, 2)) * 0.05
+
+        self.tf_01 = TF(period=period)
+        self.tf_02 = TF(period=period)
+
+        self.tf_01.impedance = z
+        self.tf_01.impedance_error = z_err
+        self.tf_01.tipper = t
+        self.tf_01.tipper_error = t_err
+
+        self.tf_02.impedance = z
+        self.tf_02.impedance_error = z_err
+        self.tf_02.tipper = t
+        self.tf_02.tipper_error = t_err
+
+    def test_ull_tf_equals(self):
+        self.assertTrue(self.tf_01.__eq__(self.tf_02))
+
+    def test_full_tf_not_equals(self):
+        self.tf_02.impedance = np.random.randn(3, 2, 2) + 1j * np.random.randn(
+            3, 2, 2
+        )
+        self.assertFalse(self.tf_01.__eq__(self.tf_02))
 
 
 class TestTFChannelNomenclature(unittest.TestCase):


### PR DESCRIPTION
To speed up initialization of an `xarray.Dataset` all the coordinates should have the same length.  Need to change this in `TF._initialize_transfer_function` such that each `xarray.DataArray` has the same coordinates as they will all be filled in when merged.  This removes redundancy and coordinate alignment slowdowns.
