### PR TITLE
Add Ability to store processing configuration in TF

### DIFF
--- a/mt_metadata/transfer_functions/core.py
+++ b/mt_metadata/transfer_functions/core.py
@@ -214,6 +214,7 @@ class TF:
                 continue
 
             setattr(result, k, deepcopy(v, memo))
+        result.logger = logger
         return result
 
     def copy(self):

--- a/mt_metadata/transfer_functions/processing/aurora/processing.py
+++ b/mt_metadata/transfer_functions/processing/aurora/processing.py
@@ -28,7 +28,6 @@ class Processing(Base):
     __doc__ = write_lines(attr_dict)
 
     def __init__(self, **kwargs):
-
         self.stations = Stations()
         self._decimations = []
         self.channel_nomenclature = ChannelNomenclature()
@@ -85,6 +84,12 @@ class Processing(Base):
                     raise TypeError(
                         f"List entry must be a DecimationLevel or dict object not {type(obj)}"
                     )
+
+        elif isinstance(value, str):
+            if len(value) > 4:
+                raise TypeError(f"Not sure what to do with {type(value)}")
+            else:
+                self._decimations = []
 
         else:
             raise TypeError(f"Not sure what to do with {type(value)}")
@@ -224,7 +229,6 @@ class Processing(Base):
                 decimation_obj.add_band(band)
             self.add_decimation_level(decimation_obj)
 
-
     def json_fn(self):
         json_fn = self.id + "_processing_config.json"
         return json_fn
@@ -280,11 +284,14 @@ class Processing(Base):
         if not self.stations.remote:
             for decimation in self.decimations:
                 if decimation.estimator.engine == "RME_RR":
-                    print("No RR station specified, switching RME_RR to RME")
+                    self.logger.info(
+                        "No RR station specified, switching RME_RR to RME"
+                    )
                     decimation.estimator.engine = "RME"
 
         # Make sure that a local station is defined
         if not self.stations.local.id:
-            print("WARNING: Local station not specified")
-            print("Local station should be set from Kernel Dataset")
+            self.logger.warning(
+                "Local station not specified, should be set from Kernel Dataset"
+            )
             self.stations.from_dataset_dataframe(kernel_dataset.df)

--- a/mt_metadata/transfer_functions/processing/aurora/stations.py
+++ b/mt_metadata/transfer_functions/processing/aurora/stations.py
@@ -5,6 +5,7 @@ Created on Thu Feb 24 13:58:07 2022
 @author: jpeacock
 """
 import pandas as pd
+
 # =============================================================================
 # Imports
 # =============================================================================
@@ -15,6 +16,7 @@ from .station import Station
 # =============================================================================
 attr_dict = get_schema("stations", SCHEMA_FN_PATHS)
 attr_dict.add_dict(get_schema("station", SCHEMA_FN_PATHS), "local")
+
 
 # =============================================================================
 class Stations(Base):
@@ -66,6 +68,11 @@ class Stations(Base):
         elif isinstance(rr_station, Station):
             rr_station.remote = True
             self._remote.append(rr_station)
+
+        elif isinstance(rr_station, str):
+            if len(rr_station) > 4:
+                raise ValueError(f"not sure to do with {type(rr_station)}")
+
         else:
             raise ValueError(f"not sure to do with {type(rr_station)}")
 
@@ -75,7 +82,9 @@ class Stations(Base):
         """
 
         if not isinstance(rr, (Station, dict)):
-            raise TypeError(f"List entry must be a Station object not {type(rr)}")
+            raise TypeError(
+                f"List entry must be a Station object not {type(rr)}"
+            )
         if isinstance(rr, dict):
             obj = Station()
             obj.from_dict(rr)
@@ -130,7 +139,7 @@ class Stations(Base):
         df = self.local.to_dataset_dataframe()
         for rr in self.remote:
             remote_df = rr.to_dataset_dataframe()
-            df = pd.concat([df, remote_df]) #, axis=1, ignore_index=True)
+            df = pd.concat([df, remote_df])  # , axis=1, ignore_index=True)
 
         df.reset_index(inplace=True, drop=True)
 

--- a/mt_metadata/transfer_functions/tf/transfer_function.py
+++ b/mt_metadata/transfer_functions/tf/transfer_function.py
@@ -19,23 +19,26 @@ from mt_metadata.timeseries.standards import (
 )
 from mt_metadata.utils.mttime import MTime
 from . import Person, Software, DataQuality
+from mt_metadata.transfer_functions.processing.aurora import Processing
 
 # =============================================================================
 attr_dict = get_schema("transfer_function", SCHEMA_FN_PATHS)
 attr_dict.add_dict(get_schema("person", TS_SCHEMA_FN_PATHS), "processed_by")
 attr_dict.add_dict(get_schema("software", TS_SCHEMA_FN_PATHS), "software")
 attr_dict.add_dict(DataQuality()._attr_dict, "data_quality")
+
+
 # =============================================================================
 class TransferFunction(Base):
     __doc__ = write_lines(attr_dict)
 
     def __init__(self, **kwargs):
-
         self.processed_by = Person()
         self.software = Software()
         self._processed_date = MTime()
         self.data_quality = DataQuality()
         self.processing_parameters = []
+        self.processing_config = None
 
         super().__init__(attr_dict=attr_dict)
 
@@ -49,3 +52,44 @@ class TransferFunction(Base):
     @processed_date.setter
     def processed_date(self, value):
         self._processed_date.parse(value)
+
+    @property
+    def processing_config(self):
+        if self._processing_config is None:
+            if len(self.processing_parameters) > 0:
+                processing_dict = {}
+                for item in self.processing_parameters:
+                    if item.startswith("aurora"):
+                        default_key = "aurora"
+                        key, value = item.split("=")
+                        key = key.replace(f"{default_key}.", "")
+                        print(key, value)
+                        processing_dict[key] = value
+                self._processing_config = Processing()
+                self._processing_config.from_dict(processing_dict)
+
+        return self._processing_config
+
+    @processing_config.setter
+    def processing_config(self, processing_config):
+        """
+        set processing config, if a Base object, processing parameters are
+        filled.
+
+        :param processing_config: DESCRIPTION
+        :type processing_config: TYPE
+        :return: DESCRIPTION
+        :rtype: TYPE
+
+        """
+        if processing_config is not None:
+            if isinstance(processing_config, Processing):
+                default_key = "aurora"
+                processing_dict = processing_config.to_dict(single=True)
+                for key, value in processing_dict.items():
+                    self.processing_parameters.append(
+                        f"{default_key}.{key}={value}"
+                    )
+                self._processing_config = processing_config
+        else:
+            self._processing_config = None

--- a/mt_metadata/transfer_functions/tf/transfer_function.py
+++ b/mt_metadata/transfer_functions/tf/transfer_function.py
@@ -19,7 +19,7 @@ from mt_metadata.timeseries.standards import (
 )
 from mt_metadata.utils.mttime import MTime
 from . import Person, Software, DataQuality
-from mt_metadata.transfer_functions.processing.aurora import Processing
+from mt_metadata.transfer_functions.processing import aurora
 
 # =============================================================================
 attr_dict = get_schema("transfer_function", SCHEMA_FN_PATHS)
@@ -55,6 +55,11 @@ class TransferFunction(Base):
 
     @property
     def processing_config(self):
+        """
+
+        :return: processing configuration
+
+        """
         if self._processing_config is None:
             if len(self.processing_parameters) > 0:
                 processing_dict = {}
@@ -64,7 +69,7 @@ class TransferFunction(Base):
                         key, value = item.split("=")
                         key = key.replace(f"{default_key}.", "")
                         processing_dict[key] = value
-                self._processing_config = Processing()
+                self._processing_config = aurora.Processing()
                 self._processing_config.from_dict(
                     {"processing": processing_dict}
                 )
@@ -77,6 +82,9 @@ class TransferFunction(Base):
         set processing config, if a Base object, processing parameters are
         filled.
 
+        To add more processing schemes need to create a Processing object for
+        that specific program and then add in
+
         :param processing_config: DESCRIPTION
         :type processing_config: TYPE
         :return: DESCRIPTION
@@ -84,7 +92,7 @@ class TransferFunction(Base):
 
         """
         if processing_config is not None:
-            if isinstance(processing_config, Processing):
+            if isinstance(processing_config, aurora.Processing):
                 default_key = "aurora"
                 processing_dict = processing_config.to_dict(single=True)
                 for key, value in processing_dict.items():

--- a/mt_metadata/transfer_functions/tf/transfer_function.py
+++ b/mt_metadata/transfer_functions/tf/transfer_function.py
@@ -63,10 +63,11 @@ class TransferFunction(Base):
                         default_key = "aurora"
                         key, value = item.split("=")
                         key = key.replace(f"{default_key}.", "")
-                        print(key, value)
                         processing_dict[key] = value
                 self._processing_config = Processing()
-                self._processing_config.from_dict(processing_dict)
+                self._processing_config.from_dict(
+                    {"processing": processing_dict}
+                )
 
         return self._processing_config
 

--- a/mt_metadata/transfer_functions/tf/transfer_function.py
+++ b/mt_metadata/transfer_functions/tf/transfer_function.py
@@ -76,6 +76,48 @@ class TransferFunction(Base):
 
         return self._processing_config
 
+    def _dict_to_params(self, object_dict, base_key):
+        """
+        dictionary to parameters
+
+        key_base.key = value
+
+        :param object_dict: DESCRIPTION
+        :type object_dict: TYPE
+        :param key_base: DESCRIPTION
+        :type key_base: TYPE
+        :return: DESCRIPTION
+        :rtype: TYPE
+
+        """
+
+        for key, value in object_dict.items():
+            if isinstance(value, list):
+                if len(value) > 0:
+                    if isinstance(value[0], dict):
+                        for item in value:
+                            if len(item.keys()) == 1:
+                                item_key = list(item.keys())[0]
+                                self._dict_to_params(
+                                    item[item_key],
+                                    f"{base_key}.{key}.{item_key}",
+                                )
+                            else:
+                                self._dict_to_params(item, f"{base_key}.{key}")
+                    else:
+                        self.processing_parameters.append(
+                            f"{base_key}.{key}={value}"
+                        )
+                else:
+                    self.processing_parameters.append(
+                        f"{base_key}.{key}={value}"
+                    )
+
+            elif isinstance(value, dict):
+                self._dict_to_params(value, f"{base_key}.{key}")
+            else:
+                self.processing_parameters.append(f"{base_key}.{key}={value}")
+
     @processing_config.setter
     def processing_config(self, processing_config):
         """
@@ -95,10 +137,7 @@ class TransferFunction(Base):
             if isinstance(processing_config, aurora.Processing):
                 default_key = "aurora"
                 processing_dict = processing_config.to_dict(single=True)
-                for key, value in processing_dict.items():
-                    self.processing_parameters.append(
-                        f"{default_key}.{key}={value}"
-                    )
+                self._dict_to_params(processing_dict, default_key)
                 self._processing_config = processing_config
         else:
             self._processing_config = None

--- a/tests/tf/processing/aurora/test_channel_nomenclature.py
+++ b/tests/tf/processing/aurora/test_channel_nomenclature.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Feb 24 14:11:24 2022
+
+@author: kkappler
+"""
+
+import unittest
+from mt_metadata.transfer_functions.processing.aurora import ChannelNomenclature
+from mt_metadata.transfer_functions.processing.aurora.channel_nomenclature import load_channel_maps
+
+class TestChannelNomenclature(unittest.TestCase):
+    """
+    Test ChannelNomenclature
+    """
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.channel_maps = load_channel_maps()
+
+    def setUp(self):
+        pass
+
+    def testLoadChannelMaps(self):
+        self.assertIsInstance(self.channel_maps, dict)
+
+
+    def test_initialization(self):
+        for keyword in self.channel_maps:
+            ch_nom = ChannelNomenclature(keyword=keyword)
+            cond = self.channel_maps[keyword] == ch_nom.get_channel_map()
+            self.assertTrue(cond)
+
+    def test_channel_sets(self):
+        keyword = list(self.channel_maps.keys())[0]
+        ch_nom = ChannelNomenclature(keyword=keyword)
+        assert len(ch_nom.ex_ey) == 2
+        assert len(ch_nom.ex_ey_hz) == 3
+        assert len(ch_nom.hx_hy) == 2
+        assert len(ch_nom.channels) == 5
+
+    def test_repr(self):
+        """ Takes the __repr__ string, and casts to a dict (via json), and compares to channel_map attr"""
+        import json
+        for keyword in self.channel_maps:
+            ch_nom = ChannelNomenclature(keyword=keyword)
+            channel_map = ch_nom.get_channel_map() # dict
+            repr = json.loads(ch_nom.__repr__())["channel_nomenclature"]
+            assert channel_map == repr
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tf/processing/aurora/test_processing.py
+++ b/tests/tf/processing/aurora/test_processing.py
@@ -11,7 +11,11 @@ Created on Fri Mar 25 11:46:46 2022
 import pandas as pd
 import unittest
 
-from mt_metadata.transfer_functions.processing.aurora import Processing
+from mt_metadata.transfer_functions.processing.aurora import (
+    Processing,
+    DecimationLevel,
+)
+
 
 # =============================================================================
 
@@ -98,8 +102,25 @@ class TestProcessingSetDecimations(unittest.TestCase):
     def test_add_decimation_level_fail(self):
         self.assertRaises(TypeError, self.p.add_decimation_level, "a")
 
-    def get_decimation_level_fail(self):
+    def test_get_decimation_level_fail(self):
         self.assertRaises(KeyError, self.p.get_decimation_level, "1")
+
+    def test_set_decimation_dict(self):
+        d = DecimationLevel()
+        self.p.decimations = {0: d}
+        with self.subTest("lenght"):
+            self.assertEqual(1, len(self.p.decimations))
+
+        with self.subTest("has keys"):
+            self.assertIn(0, self.p.decimations_dict.keys())
+
+    def test_set_decimation_list(self):
+        d = DecimationLevel().to_dict()
+        self.p.decimations = [d]
+        with self.subTest("lenght"):
+            self.assertEqual(1, len(self.p.decimations))
+        with self.subTest("has keys"):
+            self.assertIn(0, self.p.decimations_dict.keys())
 
 
 # =============================================================================

--- a/tests/tf/processing/aurora/test_processing.py
+++ b/tests/tf/processing/aurora/test_processing.py
@@ -17,7 +17,6 @@ from mt_metadata.transfer_functions.processing.aurora import Processing
 
 
 class TestProcessing(unittest.TestCase):
-
     @classmethod
     def setUpClass(self):
         starts = ["2020-01-01T00:00:00", "2020-02-02T00:00:00"]
@@ -35,7 +34,7 @@ class TestProcessing(unittest.TestCase):
                     "sample_rate": 10,
                     "input_channels": ["hx", "hy"],
                     "output_channels": ["hz", "ex", "ey"],
-                    "remote": False
+                    "remote": False,
                 }
 
                 data_list.append(entry)
@@ -49,7 +48,7 @@ class TestProcessing(unittest.TestCase):
                     "sample_rate": 10,
                     "input_channels": ["hx", "hy"],
                     "output_channels": ["hz", "ex", "ey"],
-                    "remote": True
+                    "remote": True,
                 }
                 data_list.append(rr_entry_01)
 
@@ -62,7 +61,7 @@ class TestProcessing(unittest.TestCase):
                     "sample_rate": 10,
                     "input_channels": ["hx", "hy"],
                     "output_channels": ["hz", "ex", "ey"],
-                    "remote": True
+                    "remote": True,
                 }
                 data_list.append(rr_entry_02)
         data_list = data_list
@@ -71,14 +70,40 @@ class TestProcessing(unittest.TestCase):
         df.end = pd.to_datetime(df.end)
         self.df = df
 
-
     def test_stations_to_dataframe(self):
-        """ This could be moved under test_statons.py"""
+        """This could be moved under test_statons.py"""
         p = Processing()
         p.stations.from_dataset_dataframe(self.df)
         df = p.stations.to_dataset_dataframe()
         assert len(df) == len(self.df)
 
 
+class TestProcessingSetDecimations(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.p = Processing()
+
+    def set_decimations(self, value):
+        self.p.decimations = value
+
+    def test_str_fail(self):
+        self.assertRaises(TypeError, self.set_decimations, "failing")
+
+    def test_list_fail(self):
+        self.assertRaises(TypeError, self.set_decimations, ["a", "b"])
+
+    def test_dict_fail(self):
+        self.assertRaises(TypeError, self.set_decimations, {"a": "b"})
+
+    def test_add_decimation_level_fail(self):
+        self.assertRaises(TypeError, self.p.add_decimation_level, "a")
+
+    def get_decimation_level_fail(self):
+        self.assertRaises(KeyError, self.p.get_decimation_level, "1")
+
+
+# =============================================================================
+# run
+# =============================================================================
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tf/processing/aurora/test_stations.py
+++ b/tests/tf/processing/aurora/test_stations.py
@@ -24,27 +24,46 @@ class TestStation(unittest.TestCase):
     def test_initialization(self):
         with self.subTest("test local"):
             self.assertIsInstance(self.stations.local, Station)
-        # with self.subTest("test remote type"):
-        #     self.assertIsInstance(self.stations.remote, dict)
-        # with self.subTest("test remote dict"):
-        #     self.assertEqual(self.stations.remote, {})
+        with self.subTest("test remote type"):
+            self.assertIsInstance(self.stations.remote, list)
+        with self.subTest("test remote list"):
+            self.assertEqual(self.stations.remote, [])
 
-    # def test_add_remote_station(self):
-    #     rr = Station(id="rr01")
-    #     self.stations.remote = rr
-    #     with self.subTest("is dict"):
-    #         self.assertIsInstance(self.stations.remote, dict)
-    #     with self.subTest("has keys"):
-    #         self.assertListEqual(["rr01"], list(self.stations.remote.keys()))
+    def test_add_remote_station(self):
+        rr = Station(id="rr01")
+        self.stations.remote = rr
+        with self.subTest("is list"):
+            self.assertIsInstance(self.stations.remote, list)
 
-    # def test_add_dict(self):
-    #     rr_dict = {"rr01": Station(id="rr01")}
-    #     self.stations.remote = rr_dict
-    #     with self.subTest("is dict"):
-    #         self.assertIsInstance(self.stations.remote, dict)
-    #     with self.subTest("has keys"):
-    #         self.assertListEqual(["rr01"], list(self.stations.remote.keys()))
+        with self.subTest("in keys"):
+            self.assertIn("rr01", self.stations.remote_dict.keys())
+
+    def test_add_remote_list(self):
+        rr_dict = [Station(id="rr01")]
+        self.stations.remote = rr_dict
+        with self.subTest("is list"):
+            self.assertIsInstance(self.stations.remote, list)
+        with self.subTest("list len"):
+            self.assertEqual(1, len(self.stations.remote))
+        with self.subTest("in keys"):
+            self.assertIn("rr01", self.stations.remote_dict.keys())
+
+    def test_add_remote_dict(self):
+        rr_dict = Station(id="rr01").to_dict()
+        self.stations.remote = rr_dict
+        with self.subTest("is list"):
+            self.assertIsInstance(self.stations.remote, list)
+        with self.subTest("list len"):
+            self.assertEqual(1, len(self.stations.remote))
+        with self.subTest("in keys"):
+            self.assertIn("rr01", self.stations.remote_dict.keys())
+
+    def test_get_station_fail(self):
+        self.assertRaises(KeyError, self.stations.get_station, "mt01")
 
 
+# =============================================================================
+# run
+# =============================================================================
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tf/processing/aurora/test_stations.py
+++ b/tests/tf/processing/aurora/test_stations.py
@@ -37,6 +37,8 @@ class TestStation(unittest.TestCase):
 
         with self.subTest("in keys"):
             self.assertIn("rr01", self.stations.remote_dict.keys())
+        with self.subTest("is remote"):
+            self.assertTrue(self.stations.remote[0].remote)
 
     def test_add_remote_list(self):
         rr_dict = [Station(id="rr01")]
@@ -47,6 +49,8 @@ class TestStation(unittest.TestCase):
             self.assertEqual(1, len(self.stations.remote))
         with self.subTest("in keys"):
             self.assertIn("rr01", self.stations.remote_dict.keys())
+        with self.subTest("is remote"):
+            self.assertTrue(self.stations.remote[0].remote)
 
     def test_add_remote_dict(self):
         rr_dict = Station(id="rr01").to_dict()
@@ -57,6 +61,8 @@ class TestStation(unittest.TestCase):
             self.assertEqual(1, len(self.stations.remote))
         with self.subTest("in keys"):
             self.assertIn("rr01", self.stations.remote_dict.keys())
+        with self.subTest("is remote"):
+            self.assertTrue(self.stations.remote[0].remote)
 
     def test_get_station_fail(self):
         self.assertRaises(KeyError, self.stations.get_station, "mt01")

--- a/tests/tf/test_core_tf.py
+++ b/tests/tf/test_core_tf.py
@@ -58,6 +58,13 @@ class TestTFCore(unittest.TestCase):
         other_tf = TF()
         self.assertEqual(self.tf, other_tf)
 
+    def test_copy(self):
+        other_tf = self.tf.copy()
+        with self.subTest("test equal"):
+            self.assertEqual(self.tf, other_tf)
+        with self.subTest("has logger"):
+            self.assertTrue(hasattr(other_tf, "logger"))
+
 
 class TestTFEqual(unittest.TestCase):
     def setUp(self):

--- a/tests/tf/test_station.py
+++ b/tests/tf/test_station.py
@@ -17,6 +17,8 @@ import json
 import pandas as pd
 from collections import OrderedDict
 from mt_metadata.transfer_functions.tf import Station
+from mt_metadata.transfer_functions.processing.aurora import Processing
+
 
 # =============================================================================
 #
@@ -83,7 +85,10 @@ class TestStation(unittest.TestCase):
                 ("transfer_function.processed_by.comments", "took time"),
                 ("transfer_function.processed_by.email", "email@email.com"),
                 ("transfer_function.processed_date", "2023-01-01"),
-                ("transfer_function.processing_parameters", ["param_01=10"]),
+                (
+                    "transfer_function.processing_parameters",
+                    ["aurora.id=tf_01"],
+                ),
                 (
                     "transfer_function.processing_type",
                     "robust remote reference",
@@ -168,6 +173,107 @@ class TestStation(unittest.TestCase):
     def test_declination(self):
         self.station_object.location.declination.value = "10.980"
         self.assertEqual(self.station_object.location.declination.value, 10.980)
+
+
+class TestStationTF(unittest.TestCase):
+    """
+    test station metadata
+    """
+
+    @classmethod
+    def setUpClass(self):
+        self.maxDiff = None
+        self.meta_dict = OrderedDict(
+            [
+                ("acquired_by.author", "name"),
+                ("channels_recorded", ["ex", "ey", "hx", "hy", "hz"]),
+                ("comments", "comments"),
+                ("data_type", "BBMT"),
+                ("geographic_name", "here"),
+                ("id", "mt01"),
+                ("location.declination.epoch", "2019"),
+                ("location.declination.model", "WMM"),
+                ("location.declination.value", 10.0),
+                ("location.elevation", 400.0),
+                ("location.latitude", 40.0),
+                ("location.longitude", -120.0),
+                ("orientation.angle_to_geographic_north", 0.0),
+                ("orientation.method", "compass"),
+                ("orientation.reference_frame", "geographic"),
+                ("provenance.archive.comments", "failed"),
+                ("provenance.archive.email", "email@email.com"),
+                ("provenance.archive.name", "archive name"),
+                ("provenance.archive.organization", "archive org"),
+                ("provenance.creation_time", "1980-01-01T00:00:00+00:00"),
+                ("provenance.creator.author", "author"),
+                ("provenance.creator.comments", "data comments"),
+                ("provenance.creator.email", "email@email.com"),
+                ("provenance.creator.organization", "org"),
+                ("provenance.software.author", "author"),
+                (
+                    "provenance.software.last_updated",
+                    "1980-01-01T00:00:00+00:00",
+                ),
+                ("provenance.software.name", "mt_metadata"),
+                ("provenance.software.version", "0.2.12"),
+                ("provenance.submitter.author", "author"),
+                ("provenance.submitter.comments", "data comments"),
+                ("provenance.submitter.email", "email@email.com"),
+                ("release_license", "CC0-1.0"),
+                ("run_list", ["001"]),
+                ("time_period.end", "2020-01-02T12:20:40.456000+00:00"),
+                ("time_period.start", "2020-01-02T12:20:40.456000+00:00"),
+                ("transfer_function.coordinate_system", "geopgraphic"),
+                ("transfer_function.data_quality.comments", "crushed it"),
+                ("transfer_function.data_quality.flag", None),
+                ("transfer_function.data_quality.good_from_period", 0.01),
+                ("transfer_function.data_quality.good_to_period", 1000),
+                ("transfer_function.data_quality.rating.author", "author"),
+                ("transfer_function.data_quality.rating.method", "eye ball"),
+                ("transfer_function.data_quality.rating.value", 5),
+                ("transfer_function.data_quality.warnings", "60 hz"),
+                ("transfer_function.id", "mt01_sr100"),
+                ("transfer_function.processed_by.author", "name"),
+                ("transfer_function.processed_by.comments", "took time"),
+                ("transfer_function.processed_by.email", "email@email.com"),
+                ("transfer_function.processed_date", "2023-01-01"),
+                (
+                    "transfer_function.processing_parameters",
+                    ["aurora.id=tf_01"],
+                ),
+                (
+                    "transfer_function.processing_type",
+                    "robust remote reference",
+                ),
+                ("transfer_function.remote_references", ["mtrr"]),
+                ("transfer_function.runs_processed", ["001"]),
+                ("transfer_function.sign_convention", "exp(+i\omega t)"),
+                ("transfer_function.software.author", "author"),
+                (
+                    "transfer_function.software.last_updated",
+                    "1980-01-01T00:00:00+00:00",
+                ),
+                ("transfer_function.software.version", "1.0"),
+                (
+                    "transfer_function.units",
+                    "millivolts per kilometer per nanotesla",
+                ),
+            ]
+        )
+
+        self.station_object = Station()
+        self.station_object.from_dict(self.meta_dict)
+
+    def test_transfer_function_processing_config(self):
+        self.assertIsInstance(
+            self.station_object.transfer_function.processing_config, Processing
+        )
+
+    def test_set_processed_date(self):
+        self.station_object.transfer_function.processed_date = "01-01-24"
+        self.assertEqual(
+            "2024-01-01", self.station_object.transfer_function.processed_date
+        )
 
 
 # =============================================================================

--- a/tests/tf/test_station.py
+++ b/tests/tf/test_station.py
@@ -180,8 +180,7 @@ class TestStationTF(unittest.TestCase):
     test station metadata
     """
 
-    @classmethod
-    def setUpClass(self):
+    def setUp(self):
         self.maxDiff = None
         self.meta_dict = OrderedDict(
             [
@@ -274,6 +273,50 @@ class TestStationTF(unittest.TestCase):
         self.assertEqual(
             "2024-01-01", self.station_object.transfer_function.processed_date
         )
+
+    def test_set_processing_config(self):
+        p = Processing(id="mt01")
+
+        self.station_object.transfer_function.processing_config = p
+
+        with self.subTest("dict equal"):
+            self.assertDictEqual(
+                p.to_dict(single=True),
+                self.station_object.transfer_function.processing_config.to_dict(
+                    single=True
+                ),
+            )
+        with self.subTest("processing paramters"):
+            self.assertEqual(
+                13,
+                len(
+                    self.station_object.transfer_function.processing_parameters
+                ),
+            )
+
+    def test_set_processing_config_02(self):
+        p = Processing(id="mt01")
+
+        self.station_object.transfer_function.processing_config = p
+        self.station_object.transfer_function._processing_config = None
+        self.station_object.transfer_function.processing_config.stations.local.runs = (
+            []
+        )
+
+        with self.subTest("dict equal"):
+            self.assertDictEqual(
+                p.to_dict(single=True),
+                self.station_object.transfer_function.processing_config.to_dict(
+                    single=True
+                ),
+            )
+        with self.subTest("processing paramters"):
+            self.assertEqual(
+                13,
+                len(
+                    self.station_object.transfer_function.processing_parameters
+                ),
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
Addressing issue #195 to allow for the ability to store the processing configuration on how the transfer functions are estimated.  

Need to add container in `mt_metadata.transfer_functions.tf.TransferFunction` object.  Should keep `processing_parameters` and make it work with a new attribute `processing_config`.  

- [x] Add `processing_config` to `TransferFunction`
- [x] Update tests