### PR TITLE
Minor fixes numpy 2.0

### DIFF
--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -2,7 +2,7 @@
 """
 Created on Wed Dec 23 20:37:52 2020
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -637,11 +637,18 @@ def element_to_string(element):
 # Helper function to be sure everything is encoded properly
 # =============================================================================
 class NumpyEncoder(json.JSONEncoder):
+
     """
     Need to encode numpy ints and floats for json to work
     """
 
     def default(self, obj):
+        """
+
+        :param obj:
+        :type obj:
+        :return:
+        """
         if isinstance(
             obj,
             (
@@ -659,7 +666,7 @@ class NumpyEncoder(json.JSONEncoder):
             ),
         ):
             return int(obj)
-        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
         elif isinstance(obj, (np.ndarray)):
             if obj.dtype == complex:

--- a/mt_metadata/timeseries/filters/filtered.py
+++ b/mt_metadata/timeseries/filters/filtered.py
@@ -53,7 +53,7 @@ class Filtered(Base):
         elif isinstance(names, list):
             self._name = [ss.strip().lower() for ss in names]
         elif isinstance(names, np.ndarray):
-            names = names.astype(np.unicode_)
+            names = names.astype(np.str_)
             self._name = [ss.strip().lower() for ss in names]
         else:
             msg = "names must be a string or list of strings not {0}, type {1}"

--- a/mt_metadata/utils/validators.py
+++ b/mt_metadata/utils/validators.py
@@ -490,7 +490,7 @@ def validate_value_type(value, v_type, style=None):
         elif isinstance(value, Iterable):
             if v_type is str:
                 if isinstance(value, np.ndarray):
-                    value = value.astype(np.unicode_)
+                    value = value.astype(np.str_)
                 value = [
                     f"{v}".replace("'", "").replace('"', "") for v in value
                 ]

--- a/mt_metadata/utils/validators.py
+++ b/mt_metadata/utils/validators.py
@@ -378,6 +378,15 @@ def validate_default(value_dict):
 
 def validate_value_type(value, v_type, style=None):
     """
+
+    :param value:
+    :type value:
+    :param v_type:
+    :type v_type:
+    :param style:
+    :type style:
+    :return:
+
     validate type from standards
 
     """
@@ -469,7 +478,7 @@ def validate_value_type(value, v_type, style=None):
 
         # if a number convert to appropriate type
         elif isinstance(
-            value, (float, np.float_, np.float16, np.float32, np.float64)
+            value, (float, np.float16, np.float32, np.float64)
         ):
             if v_type is int:
                 return int(value)


### PR DESCRIPTION

- [X] MTH5 notebooks failing on python >=3.9 due to:
  - AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead
  - removed `np.float_` reference, float64 was already there