### PR TITLE
Fix issue 238 housekeeping (continued)

### DIFF
--- a/mt_metadata/transfer_functions/processing/aurora/decimation_level.py
+++ b/mt_metadata/transfer_functions/processing/aurora/decimation_level.py
@@ -48,6 +48,7 @@ def df_from_bands(band_list: List[Union[Band, dict, None]]) -> pd.DataFrame:
         Not clear this is really necessary
     TODO: Consider making this a method of FrequencyBands() class.
     TODO: Check typehint -- should None be allowed value in the band_list?
+    TODO: Consider adding columns lower_closed, upper_closed to df
 
     Parameters
     ----------
@@ -182,10 +183,7 @@ class DecimationLevel(Base):
         """
         Utility function that transforms a list of bands into a dataframe
 
-        Note: The decimation_level here is +1 to agree with EMTF convention.
-        Not clear this is really necessary
-
-        TODO: Consider adding columns lower_closed, upper_closed to df
+        See notes in `df_from_bands`.
 
         Returns
         -------

--- a/mt_metadata/transfer_functions/processing/aurora/decimation_level.py
+++ b/mt_metadata/transfer_functions/processing/aurora/decimation_level.py
@@ -420,7 +420,7 @@ class DecimationLevel(Base):
             msg = "WIP: harmonic indices in AuroraDecimationlevel are derived from processing bands -- Not robustly tested to compare with FCDecimation"
             self.logger.debug(msg)
             harmonic_indices_requested = self.harmonic_indices
-            fcdec_group_set = set(fc_decimation.harmonic_indices)
+            fcdec_group_set = set(fc_decimation.stft.harmonic_indices)
             processing_set = set(harmonic_indices_requested)
             if processing_set.issubset(fcdec_group_set):
                 pass

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -101,10 +101,6 @@ class Decimation(Base):
     def stft(self):
         return self.short_time_fourier_transform
 
-    @property
-    def harmonic_indices(self):
-        return self.short_time_fourier_transform.harmonic_indices
-
     #----- End (Possibly Temporary) methods for integrating TimeSeriesDecimation, STFT Classes -----#
 
     def update(self, other, match=[]):

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -98,22 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def decimation_level(self) -> int:
-        """
-            Access the decimation level from the TSDecimation
-            :return: Integer decimation level
-            :rtype: int
-        """
-        return self.time_series_decimation.level
-
-    @decimation_level.setter
-    def decimation_level(self, value: int) -> None:
-        """
-            Set the decimation level in the TSDecimation
-        """
-        self.time_series_decimation.level = value
-
-    @property
     def decimation_factor(self) -> float:
         """
             Access the decimation factor from the TSDecimation

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -88,7 +88,7 @@ class Decimation(Base):
             self.logger.error(msg)
             raise TypeError(msg)
 
-    #----- Begin (Possibly Temporary) methods for integrating TimeSeriesDecimation Class -----#
+    #----- Begin (Possibly Temporary) methods for integrating TimeSeriesDecimation, STFT Classes -----#
 
     @property
     def decimation(self) -> TimeSeriesDecimation:
@@ -98,20 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def decimation_sample_rate(self) -> float:
-        """
-            Access the decimation sample rate from the TSDecimation
-            :return: Time series sample rate after decimation (from the TSDecimation)
-            :rtype: float
-        """
-        return self.time_series_decimation.sample_rate
-
-
-    #----- End (Possibly Temporary) methods for integrating TimeSeriesDecimation Class -----#
-
-    #----- Begin (Possibly Temporary) methods for integrating ShortTimeFourierTransform Class -----#
-
-    @property
     def stft(self):
         return self.short_time_fourier_transform
 
@@ -119,7 +105,7 @@ class Decimation(Base):
     def harmonic_indices(self):
         return self.short_time_fourier_transform.harmonic_indices
 
-    #----- End (Possibly Temporary) methods for integrating ShortTimeFourierTransform Class -----#
+    #----- End (Possibly Temporary) methods for integrating TimeSeriesDecimation, STFT Classes -----#
 
     def update(self, other, match=[]):
         """

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -98,22 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def decimation_factor(self) -> float:
-        """
-            Access the decimation factor from the TSDecimation
-            :return: decimation factor
-            :rtype: float
-        """
-        return self.time_series_decimation.factor
-
-    @decimation_factor.setter
-    def decimation_factor(self, value: float) -> None:
-        """
-            Set the decimation factor in the TSDecimation
-        """
-        self.time_series_decimation.factor = value
-
-    @property
     def decimation_method(self) -> str:
         """
             Access the decimation method from the TSDecimation

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -98,22 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def decimation_method(self) -> str:
-        """
-            Access the decimation method from the TSDecimation
-            :return: Description of how decimation is performed
-            :rtype: str
-        """
-        return self.time_series_decimation.method
-
-    @decimation_method.setter
-    def decimation_method(self, value: str) -> None:
-        """
-            Set the decimation level in the TSDecimation
-        """
-        self.time_series_decimation.method = value
-
-    @property
     def decimation_sample_rate(self) -> float:
         """
             Access the decimation sample rate from the TSDecimation

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -98,16 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def factor(self):
-        """
-        TODO: DELETE THIS IN 2025: factor should be deprecated, use TimeSeriesDecimation for this info.
-        """
-        msg = ("This method will be deprecated in a future release.  Use "
-               "self.time_series_decimation.factor or self.decimation_factor instead")
-        logger.warning(msg)
-        return self.decimation_factor
-
-    @property
     def sample_rate(self) -> float:
         return self.time_series_decimation.sample_rate
 

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/decimation.py
@@ -98,10 +98,6 @@ class Decimation(Base):
         return self.time_series_decimation
 
     @property
-    def sample_rate(self) -> float:
-        return self.time_series_decimation.sample_rate
-
-    @property
     def decimation_level(self) -> int:
         """
             Access the decimation level from the TSDecimation
@@ -415,7 +411,7 @@ class Decimation(Base):
     @property
     def fft_frequencies(self) -> np.ndarray:
         """ Returns the one-sided fft frequencies (without Nyquist)"""
-        return self.stft.window.fft_harmonics(self.sample_rate)
+        return self.stft.window.fft_harmonics(self.decimation.sample_rate)
 
 
 def fc_decimations_creator(

--- a/mt_metadata/transfer_functions/processing/fourier_coefficients/fc.py
+++ b/mt_metadata/transfer_functions/processing/fourier_coefficients/fc.py
@@ -97,7 +97,7 @@ class FC(Base):
         """list of decimation levels"""
         dl_list = []
         for dl in self.levels:
-            dl_list.append(dl.decimation_level)
+            dl_list.append(dl.decimation.level)
         dl_list = sorted(set([cc for cc in dl_list if cc is not None]))
         if self._decimation_levels == []:
             return dl_list
@@ -201,7 +201,7 @@ class FC(Base):
         if self.has_decimation_level(level):
             return self.levels[str(level)]
 
-    def add_decimation_level(self, decimation_level_obj):
+    def add_decimation_level(self, fc_decimation):
         """
         Add a decimation_level to the list, check if one exists if it does overwrite it
 
@@ -209,21 +209,21 @@ class FC(Base):
         :type decimation_level_obj: :class:`mt_metadata.transfer_functions.processing.fourier_coefficients.decimation_level`
 
         """
-        if not isinstance(decimation_level_obj, (Decimation)):
-            msg = f"Input must be metadata.decimation_level not {type(decimation_level_obj)}"
+        if not isinstance(fc_decimation, (Decimation)):
+            msg = f"Input must be metadata.decimation_level not {type(fc_decimation)}"
             self.logger.error(msg)
             raise ValueError(msg)
 
-        if self.has_decimation_level(decimation_level_obj.decimation_level):
-            self.levels[decimation_level_obj.decimation_level].update(
-                decimation_level_obj
+        if self.has_decimation_level(fc_decimation.decimation.level):
+            self.levels[fc_decimation.decimation.level].update(
+                fc_decimation
             )
             self.logger.debug(
-                f"ch {decimation_level_obj.level} already exists, updating metadata"
+                f"ch {fc_decimation.decimation.level} already exists, updating metadata"
             )
 
         else:
-            self.levels.append(decimation_level_obj)
+            self.levels.append(fc_decimation)
 
         self.update_time_period()
 

--- a/tests/tf/processing/fcs/test_decimation.py
+++ b/tests/tf/processing/fcs/test_decimation.py
@@ -48,10 +48,10 @@ class TestDecimation(unittest.TestCase):
     def setUpClass(self):
 
         self.dl = Decimation()
-        self.dl.decimation_factor = 4
-        self.dl.decimation_level = 1
+        self.dl.decimation.factor = 4
+        self.dl.decimation.level = 1
         self.dl.id = 1
-        self.dl.time_series_decimation.sample_rate = 16.0
+        self.dl.decimation.sample_rate = 16.0
 
         self.start = "2020-01-01T00:00:00+00:00"
         self.end = "2020-01-01T00:20:00+00:00"
@@ -186,9 +186,6 @@ class TestDecimation(unittest.TestCase):
         with self.subTest("end"):
             self.assertEqual(self.end, self.dl.time_period.end)
 
-    def test_factor(self):
-        self.assertEqual(self.dl.decimation_factor, self.dl.factor)
-
     def test_window_length_true(self):
         self.assertEqual(True, self.dl.is_valid_for_time_series_length(4096))
 
@@ -200,8 +197,8 @@ class TestDecimationAuroraDecimationLevel(unittest.TestCase):
     def setUp(self):
 
         self.dl = Decimation()
-        self.dl.decimation_factor = 4
-        self.dl.decimation_level = 1
+        self.dl.decimation.factor = 4
+        self.dl.decimation.level = 1
         self.dl.id = 1
         self.dl.time_series_decimation.sample_rate = 16
         for ch in ["ex", "ey", "hx", "hy", "hz"]:

--- a/tests/tf/processing/fcs/test_fc.py
+++ b/tests/tf/processing/fcs/test_fc.py
@@ -41,8 +41,8 @@ class TestFC(unittest.TestCase):
         self.fc.starting_sample_rate = 64
 
         self.dl = Decimation()
-        self.dl.decimation_factor = 4
-        self.dl.decimation_level = 1
+        self.dl.decimation.factor = 4
+        self.dl.decimation.level = 1
         self.dl.id = 1
         self.dl.time_series_decimation.sample_rate = 16.0
 
@@ -76,7 +76,7 @@ class TestFC(unittest.TestCase):
         fc2 = self.fc.copy()
         fc2.levels.remove("1")
         dl2 = self.dl.copy()
-        dl2.decimation_level = 6
+        dl2.decimation.level = 6
         dl2.id = 6
         fc2.add_decimation_level(dl2)
 
@@ -89,7 +89,7 @@ class TestFC(unittest.TestCase):
         fc2 = self.fc.copy()
         fc2.levels.remove("1")
         dl2 = self.dl.copy()
-        dl2.decimation_level = 6
+        dl2.decimation.level = 6
         dl2.id = 6
         fc2.add_decimation_level(dl2)
 


### PR DESCRIPTION
Now that the factoring of stft and decimation out of FCDecimation and AuroraDecimationLevel is done, go back and clean up temporary methods that made tests pass during factor.

- [x]  remove sample_rate_decimation attr, and replace with direct access to decimation.sample_rate
- [x] remove duplicate run_ts_to_stft_scipy in mth5 (stft.py, and helpers.py)
- [x]  replace factor method in FCDecimation with access self.decimation.factor
- [x]  replace sample_rate property in FCDecimation with access self.decimation.sample_rate
- [x]  replace decimation_level getters/setters with self.decimation.level
- [x]  replace decimation_factor getters/setters with self.decimation.factor
- [x]  replace decimation_method getters/setters with self.decimation.method
- [x]  remove unused decimation_sample_rate method
- [x]  remove unused harmonic_indices method
