### PR TITLE
Reduce redundant validations on metadata instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+# IDE related
+# PyCharm
+.idea/

--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -457,7 +457,7 @@ def recursive_split_setattr(base_object, name, value, sep=".", skip_val=False):
             base_object = getattr(base_object, key)
             recursive_split_setattr(base_object, other[0], value, skip_val=True)
         else:
-            base_object.setattr_skip_validation(base_object, key, value)
+            base_object.setattr_skip_validation(key, value)
     else:
         if other:
             base_object = getattr(base_object, key)

--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -449,14 +449,21 @@ def recursive_split_getattr(base_object, name, sep="."):
     return value, prop
 
 
-def recursive_split_setattr(base_object, name, value, sep="."):
+def recursive_split_setattr(base_object, name, value, sep=".", skip_val=False):
     key, *other = name.split(sep, 1)
 
-    if other:
-        base_object = getattr(base_object, key)
-        recursive_split_setattr(base_object, other[0], value)
+    if skip_val:
+        if other:
+            base_object = getattr(base_object, key)
+            recursive_split_setattr(base_object, other[0], value, skip_val=True)
+        else:
+            base_object.setattr_skip_validation(base_object, key, value)
     else:
-        setattr(base_object, key, value)
+        if other:
+            base_object = getattr(base_object, key)
+            recursive_split_setattr(base_object, other[0], value)
+        else:
+            setattr(base_object, key, value)
 
 
 def structure_dict(meta_dict, sep="."):

--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -449,13 +449,31 @@ def recursive_split_getattr(base_object, name, sep="."):
     return value, prop
 
 
-def recursive_split_setattr(base_object, name, value, sep=".", skip_val=False):
+def recursive_split_setattr(base_object, name, value, sep=".", skip_validation=False):
+    """
+    Recursively split a name and set the value of the last key. Recursion splits on the separator present in the name.
+
+    :param base_object: The object having its attribute set, or a "parent" object in the recursive/nested scenario
+    :type base_object: object
+    :param name: The name of the attribute to set
+    :type name: str
+    :param value: The value to set the attribute to
+    :type value: any
+    :param sep: The separator to split the name on, defaults to "."
+    :type sep: str, optional
+    :param skip_validation: Whether to skip validation/parse of the attribute, defaults to False
+    :type skip_validation: Optional[bool]
+
+    :return: None
+    :rtype: NoneType
+
+    """
     key, *other = name.split(sep, 1)
 
-    if skip_val:
+    if skip_validation:
         if other:
             base_object = getattr(base_object, key)
-            recursive_split_setattr(base_object, other[0], value, skip_val=True)
+            recursive_split_setattr(base_object, other[0], value, skip_validation=True)
         else:
             base_object.setattr_skip_validation(key, value)
     else:

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -50,15 +50,13 @@ class Base:
         self.logger = logger
         self._debug = False
 
-        if not self._base_attr_loaded:
-            # silly: attr_dict has already been validated on json load, so we don't need to validate it again
-            self._set_attr_dict(attr_dict, skip_val=True)
-            self._base_attr_loaded = True
+        # attr_dict from subclass has already been validated on json load, so we don't need to validate it again
+        self._set_attr_dict(attr_dict, skip_validation=True)
 
         for name, value in kwargs.items():
-            self.set_attr_from_name(name, value, skip_val=False)
+            self.set_attr_from_name(name, value, skip_validation=False)
 
-    def _set_attr_dict(self, attr_dict, skip_val=False):
+    def _set_attr_dict(self, attr_dict, skip_validation=False):
         """
         Set attribute dictionary and variables.
 
@@ -66,13 +64,15 @@ class Base:
 
         :param attr_dict: attribute dictionary
         :type attr_dict: dict
+        :param skip_validation: skip validation/parse of the attribute dictionary
+        :type skip_validation: bool
 
         """
 
         self._attr_dict = attr_dict
 
         for key, value_dict in attr_dict.items():
-            self.set_attr_from_name(key, value_dict["default"], skip_val)
+            self.set_attr_from_name(key, value_dict["default"], skip_validation)
 
     def __str__(self):
         """
@@ -491,7 +491,7 @@ class Base:
         """
         self.__dict__[name] = value
 
-    def set_attr_from_name(self, name, value, skip_val=False):
+    def set_attr_from_name(self, name, value, skip_validation=False):
         """
         Helper function to set attribute from the given name.
 
@@ -505,6 +505,8 @@ class Base:
         :type name: string
         :param value: attribute value
         :type value: type is defined by the attribute name
+        :param skip_validation: skip validation/parse of the key-value pair
+        :type skip_validation: bool
 
         :Example:
 
@@ -515,7 +517,7 @@ class Base:
         """
         if "." in name:
             try:
-                helpers.recursive_split_setattr(self, name, value, skip_val=skip_val)
+                helpers.recursive_split_setattr(self, name, value, skip_validation=skip_validation)
             except AttributeError as error:
                 msg = (
                     "{0} is not in the current standards.  "
@@ -526,7 +528,7 @@ class Base:
                 self.logger.error(msg.format(name))
                 raise AttributeError(error)
         else:
-            if skip_val:
+            if skip_validation:
                 self.setattr_skip_validation(name, value)
             else:
                 setattr(self, name, value)

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -31,6 +31,8 @@ from . import helpers
 from mt_metadata.base.helpers import write_lines
 
 attr_dict = {}
+
+
 # =============================================================================
 #  Base class that everything else will inherit
 # =============================================================================
@@ -119,7 +121,7 @@ class Base:
                         if value.size != other_value.size:
                             msg = f"Array sizes for {key} differ: {value.size} != {other_value.size}"
                             self.logger.info(msg)
-                            fail=True
+                            fail = True
                             continue
                         if not (value == other_value).all():
                             msg = f"{key}: {value} != {other_value}"
@@ -476,9 +478,7 @@ class Base:
             return value
         return self._validate_type(value, v_type)
 
-
-    @staticmethod
-    def setattr_skip_validation(self_obj, name, value):
+    def setattr_skip_validation(self, name, value):
         """
         Set attribute without validation
 
@@ -489,11 +489,7 @@ class Base:
         :type value: described in value_dict
 
         """
-        if isinstance(self_obj, Base):
-            self_obj.__dict__[name] = value
-        else:  # class obj
-            setattr(self_obj, name, value)
-
+        self.__dict__[name] = value
 
     def set_attr_from_name(self, name, value, skip_val=False):
         """
@@ -531,7 +527,7 @@ class Base:
                 raise AttributeError(error)
         else:
             if skip_val:
-                self.setattr_skip_validation(self, name, value)
+                self.setattr_skip_validation(name, value)
             else:
                 setattr(self, name, value)
 

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -50,7 +50,8 @@ class Base:
         self.logger = logger
         self._debug = False
 
-        # attr_dict from subclass has already been validated on json load, so we don't need to validate it again
+        # attr_dict from subclass has already been validated on json load, so we shouldn't need to validate it again...
+        # re-validation of the attribute dictionary used to contribute to some slowness in instantiation of subclasses
         self._set_attr_dict(attr_dict, skip_validation=True)
 
         for name, value in kwargs.items():

--- a/mt_metadata/base/schema.py
+++ b/mt_metadata/base/schema.py
@@ -2,7 +2,7 @@
 """
 Created on Thu Dec 24 12:02:12 2020
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT


### PR DESCRIPTION
This is my first PR in this repo, so please do point out any deficiencies in the request. I am always open to discussion!

## Background
- In using [MTH5](https://github.com/kujaku11/mth5) and by extension this library, we have found some issues with performance. This has been most noticeable in our airborne processing, in which the number of "stations" can greatly exceed what would be normal in ground MT
- Despite some hacks locally in our processing to greatly reduce data duplication in the airborne case by storing only the time indices (2 numbers) for every run in a station (as it relates to a flight timeseries), we noticed a surprising performance hits in [MTH5's groups.run](https://github.com/kujaku11/mth5/blob/master/mth5/groups/run.py) functions `to_runts` and `from_runts`. In these, one of the notable (but perhaps not the largest) hits in performance is the time spent generating metadata objects. In a light investigation, some of this slowness comes from erroneously/repeatedly validating the attr_dict objects which have already been validated on first import, and on each instantiation of the metadata.

## Changes
- Adds an argument `skip_validation` (default False) tracing from `metadata.Base._set_attr_dict()` through to the actual attribute setting on the base_object in `helpers.recursive_split_setattr()`. As "validation" also includes some amount of formatting, parsing, etc, this argument is only safe if you know that the incoming property or properties have already been validated. Fortunately this seems to always be the case when any subclass of metadata.Base calls super().__init__(), as the global-scope JSON parsing does this same validation when building each attr_dict. Therefore, we can skip re-validating the entire base schema for each object on every instantiation of a subclass.
- Minor .gitignore update to avoid committing PyCharm files to the repo 

## Impact
- Using the code tacked to the bottom of this PR description, the median time to instantiate a `Station()` decreased on my machine from  0.0012488s to 0.0003102s, which is an improvement of about ~4x.  
- I don't expect this to be a huge improvement to most processing flows, but in my (admittedly not perfect) survey of the slow MTH5 code, there is a surprising amount of instantiations especially in those schema's that have many sub-schema's, sub-sub-schema's, etc. 
- This change's location is just about as load bearing as it gets, and this change is expected to impact all consumers of the library. Appropriate cautions should be taken.

## Testing
- Have had some difficulty in getting tests to run in my local machine, even on unchanged code. I will be monitoring the GitHub Actions on this PR, and if issues come up plan to put more effort into replicating the issues locally.
- Our airborne processing code has been able to run to completion for ~500 "stations" after the modifications to mt_metadata. This was done before a couple cleanup commits, but besides those the changes are at least not fundamentally broken for MTH5
- The existing base of tests *should* do a good job testing this addition, due to where the change is and what it affects. A comprehensive test would be extremely difficult... but I am open to implementing any tests that could tease out potential edge cases, if requested

timing code:
```python
import time
import numpy as np
from mt_metadata import timeseries

"""
0.0003101998008787632
0.0012488001957535744
"""

if __name__ == '__main__':
    x = 50000
    times = []
    for i in range(x):
        t0 = time.perf_counter()
        station = timeseries.Station()
        t1 = time.perf_counter()
        times.append(t1 - t0)
    m = np.median(times)
    print(f"Station(): {m} seconds")
 ```