### PR TITLE
Make obspy optional.

### DIFF
--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -9,13 +9,14 @@ on:
       - '*'
 jobs:
   setup-build:
-    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }}) (${{ matrix.optionals}})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        optionals: ["", "obspy"]
     defaults:
       run:
         shell: bash -el {0}
@@ -37,6 +38,12 @@ jobs:
       run: |
         pip install -e .
         conda list
+
+    - name: Install optionals
+      run: |
+        pip install -e .[${{ matrix.optionals }}]
+        conda list
+      if: ${{ matrix.optionals }}
 
     - name: Run Tests
       run: pytest --cov=./ --cov-report=xml --cov=mt_metadata

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -16,40 +16,35 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        update-conda: false
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
 
     - name: Install Env
-      shell: bash
       run: |
         python --version
-        conda create -n mtmetadata-test python=${{ matrix.python-version }}
-        source activate mtmetadata-test
         conda install pytest
         conda install pytest-cov
-        
+
     - name: Install Our Package
-      shell: bash
       run: |
-        source activate mtmetadata-test
         pip install -e .
         conda list
+
     - name: Run Tests
-      shell: bash
-      run: |
-        source activate mtmetadata-test
-        pytest --cov=./ --cov-report=xml --cov=mt_metadata
-        
+      run: pytest --cov=./ --cov-report=xml --cov=mt_metadata
+
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false
         verbose: true
         flags: tests
-        
+

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 MT Metadata is a project led by [IRIS-PASSCAL MT Software working group](https://www.iris.edu/hq/about_iris/governance/mt_soft>) and USGS to develop tools that standardize magnetotelluric metadata, well, at least create tools for standards that are generally accepted.  This include the two main types of magnetotelluric data
 
-- **Time Series** 
+- **Time Series**
     - Structured as:
         - Experiment -> Survey -> Station -> Run -> Channel
     - Supports translation to/from **StationXML**
-        
+
 - **Transfer Functions**
     - Supports (will support) to/from:
         - **EDI** (most common format)
@@ -41,12 +41,19 @@ Most people will be using the transfer functions, but a lot of that metadata com
 
 `git clone https://github.com/kujaku11/mt_metadata.git`
 
-`python setup.py install`
+`pip install .`
 
-You can add the flag `-e` if you want to change the code.
+You can add the flag `-e` if you want to install the source repository in an editable state.
 
 ## PIP
 `pip install mt_metadata`
+
+> You can install with optional packages by appending `[option_name]` to the package name during the
+> `pip` install command. E.g:
+>
+> `pip install mt_metadata[obspy]`
+>
+> or `pip install .[obspy]` if building from source.
 
 ## Conda
 
@@ -54,7 +61,7 @@ You can add the flag `-e` if you want to change the code.
 
 # Standards
 
-Each metadata keyword has an associated standard that goes with it.  These are stored internally in JSON file.  The JSON files are read in when the package is loaded to initialize the standards.  Each keyword is described by:  
+Each metadata keyword has an associated standard that goes with it.  These are stored internally in JSON file.  The JSON files are read in when the package is loaded to initialize the standards.  Each keyword is described by:
 
 - **type** - How the value should be represented based on very basic types
 
@@ -70,7 +77,7 @@ Each metadata keyword has an associated standard that goes with it.  These are s
     - *Controlled Vocabulary* only certain values are allowed according to **options**
     - *Date* a date and/or time string in ISO format
     - *Number* a float or integer
-    - *Boolean* the value can only be True or False 
+    - *Boolean* the value can only be True or False
 
 - **units** - Units of the value
 - **description** - Full description of what the metadata key is meant to convey.
@@ -87,7 +94,7 @@ Each metadata object is based on a Base class that has methods:
 - to_from_dict
 - attribute_information
 
-And each object has a doc string that describes the standard: 
+And each object has a doc string that describes the standard:
 
 
 | **Metadata Key**                             | **Description**                               | **Example**    |
@@ -200,4 +207,4 @@ print(x.to_xml(string=True))
 Credits
 -------
 
-This project is in cooperation with the Incorporated Research Institutes of Seismology, the U.S. Geological Survey, and other collaborators.  Facilities of the IRIS Consortium are supported by the National Science Foundation’s Seismological Facilities for the Advancement of Geoscience (SAGE) Award under Cooperative Support Agreement EAR-1851048.  USGS is partially funded through the Community for Data Integration and IMAGe through the Minerals Resources Program. 
+This project is in cooperation with the Incorporated Research Institutes of Seismology, the U.S. Geological Survey, and other collaborators.  Facilities of the IRIS Consortium are supported by the National Science Foundation’s Seismological Facilities for the Advancement of Geoscience (SAGE) Award under Cooperative Support Agreement EAR-1851048.  USGS is partially funded through the Community for Data Integration and IMAGe through the Minerals Resources Program.

--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -701,8 +701,8 @@ def requires(**requirements):
 
     Parameters
     ----------
-    **requirements : dict[str, obj]
-        Dictionary of package name and object pairs required for
+    **requirements : obj
+        keywords of package name and the required object for
         a function.
 
     Returns

--- a/mt_metadata/base/helpers.py
+++ b/mt_metadata/base/helpers.py
@@ -694,3 +694,52 @@ def validate_name(name, pattern=None):
     if name is None:
         return "unknown"
     return name.replace(" ", "_")
+
+
+def requires(**requirements):
+    """Decorate a function with optional dependencies.
+
+    Parameters
+    ----------
+    **requirements : dict[str, obj]
+        Dictionary of package name and object pairs required for
+        a function.
+
+    Returns
+    -------
+    decorated_function : function
+        Original function if all soft dependencies are met, otherwise
+        it returns an empty function which prints why it is not running.
+
+    Examples
+    --------
+    ```
+    try:
+        import obspy
+    except ImportError:
+        obspy = None
+
+    @requires(obspy=obspy)
+    def obspy_function():
+        ...
+        # does something using obspy
+
+    """
+    # Check the requirements, add missing package name in the list `missing`.
+    missing = []
+    for key, item in requirements.items():
+        if not item:
+            missing.append(key)
+
+    def decorated_function(function):
+        """Wrap function."""
+        if not missing:
+            return function
+        else:
+            def passer(*args, **kwargs):
+                print(("Missing dependencies: {d}.".format(d=missing)))
+                print(("Not running `{}`.".format(function.__name__)))
+
+            return passer
+
+    return decorated_function

--- a/mt_metadata/timeseries/filters/channel_response.py
+++ b/mt_metadata/timeseries/filters/channel_response.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 import numpy as np
 
 from mt_metadata.base import Base, get_schema
+from mt_metadata.base.helpers import requires
 from mt_metadata.timeseries.filters.standards import SCHEMA_FN_PATHS
 from mt_metadata.timeseries.filters import (
     PoleZeroFilter,
@@ -27,7 +28,10 @@ from mt_metadata.timeseries.filters import (
 from mt_metadata.timeseries.filters.filter_base import FilterBase
 from mt_metadata.utils.units import get_unit_object
 from mt_metadata.timeseries.filters.plotting_helpers import plot_response
-from obspy.core import inventory
+try:
+    from obspy.core import inventory
+except ImportError:
+    inventory = None
 
 # =============================================================================
 attr_dict = get_schema("channel_response", SCHEMA_FN_PATHS)
@@ -375,6 +379,7 @@ class ChannelResponse(Base):
 
         return True
 
+    @requires(obspy=inventory)
     def to_obspy(self, sample_rate=1):
         """
         Output :class:`obspy.core.inventory.InstrumentSensitivity` object that

--- a/mt_metadata/timeseries/filters/coefficient_filter.py
+++ b/mt_metadata/timeseries/filters/coefficient_filter.py
@@ -1,13 +1,13 @@
-import copy
 import numpy as np
-from obspy.core import inventory
+try:
+    from obspy.core import inventory
+except ImportError:
+    inventory = None
 
 from mt_metadata.base import get_schema
 from mt_metadata.timeseries.filters.filter_base import FilterBase
-from mt_metadata.timeseries.filters.filter_base import get_base_obspy_mapping
 from mt_metadata.timeseries.filters.standards import SCHEMA_FN_PATHS
-from mt_metadata.base.helpers import write_lines
-
+from mt_metadata.base.helpers import write_lines, requires
 
 # =============================================================================
 attr_dict = get_schema("filter_base", SCHEMA_FN_PATHS)
@@ -27,6 +27,7 @@ class CoefficientFilter(FilterBase):
         if self.gain == 0.0:
             self.gain = 1.0
 
+    @requires(obspy=inventory)
     def to_obspy(
         self,
         stage_number=1,

--- a/mt_metadata/timeseries/filters/filter_base.py
+++ b/mt_metadata/timeseries/filters/filter_base.py
@@ -41,8 +41,6 @@ of the filter in frequency domain.  It is very similar to an "obspy filter stage
 # =============================================================================
 # Imports
 # =============================================================================
-import copy
-import obspy
 import numpy as np
 
 from mt_metadata.base.helpers import write_lines
@@ -261,20 +259,17 @@ class FilterBase(Base):
 
         """
 
-        if not isinstance(stage, obspy.core.inventory.response.ResponseStage):
-            msg = f"Expected a Stage and got a {type(stage)}"
-            cls().logger.error(msg)
-            raise TypeError(msg)
-
         if mapping is None:
             mapping = cls().make_obspy_mapping()
         kwargs = {}
-        for obspy_label, mth5_label in mapping.items():
-            try:
-                kwargs[mth5_label] = stage.__dict__[obspy_label]
-            except KeyError:
-                print(f"Key {obspy_label} not found in stage object")
-                raise Exception
+
+        try:
+            for obspy_label, mth5_label in mapping.items():
+                    kwargs[mth5_label] = getattr(stage, obspy_label)
+        except AttributeError:
+            msg = f"Expected a Stage and got a {type(stage)}"
+            cls().logger.error(msg)
+            raise TypeError(msg)
         return cls(**kwargs)
 
     def complex_response(self, frqs):

--- a/mt_metadata/timeseries/filters/fir_filter.py
+++ b/mt_metadata/timeseries/filters/fir_filter.py
@@ -1,6 +1,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from obspy.core.inventory.response import FIRResponseStage
+
+from mt_metadata.base.helpers import requires
+
+try:
+    from obspy.core.inventory.response import FIRResponseStage
+except ImportError:
+    FIRResponseStage = None
 import scipy.signal as signal
 
 from mt_metadata.base import get_schema
@@ -124,6 +130,7 @@ class FIRFilter(FilterBase):
         plt.axis("tight")
         plt.show()
 
+    @requires(obspy=FIRResponseStage)
     def to_obspy(
         self, stage_number=1, normalization_frequency=1, sample_rate=1,
     ):

--- a/mt_metadata/timeseries/filters/frequency_response_table_filter.py
+++ b/mt_metadata/timeseries/filters/frequency_response_table_filter.py
@@ -10,10 +10,15 @@
 import numpy as np
 from scipy.interpolate import interp1d
 
-from obspy.core.inventory.response import (
-    ResponseListResponseStage,
-    ResponseListElement,
-)
+from mt_metadata.base.helpers import requires
+
+try:
+    from obspy.core.inventory.response import (
+        ResponseListResponseStage,
+        ResponseListElement,
+    )
+except ImportError:
+    ResponseListResponseStage = ResponseListElement = None
 
 from mt_metadata.base import get_schema
 from mt_metadata.timeseries.filters.filter_base import FilterBase
@@ -166,6 +171,7 @@ class FrequencyResponseTableFilter(FilterBase):
         """
         return self._empirical_frequencies.max()
 
+    @requires(obspy=(ResponseListResponseStage and ResponseListElement))
     def to_obspy(
         self,
         stage_number=1,

--- a/mt_metadata/timeseries/filters/helper_functions.py
+++ b/mt_metadata/timeseries/filters/helper_functions.py
@@ -1,5 +1,3 @@
-import obspy
-
 from loguru import logger
 from mt_metadata.timeseries.filters.coefficient_filter import CoefficientFilter
 from mt_metadata.timeseries.filters.frequency_response_table_filter import (

--- a/mt_metadata/timeseries/filters/obspy_stages.py
+++ b/mt_metadata/timeseries/filters/obspy_stages.py
@@ -6,7 +6,6 @@ Idea here is to add logic to interrogate stage filters received from StationXML
 # Imports
 # =============================================================================
 import numpy as np
-import obspy
 from loguru import logger
 
 from mt_metadata.timeseries.filters import (
@@ -124,7 +123,7 @@ def create_filter_from_stage(stage):
 
     """
 
-    if isinstance(stage, obspy.core.inventory.response.PolesZerosResponseStage):
+    try:
         if stage.poles == [] and stage.zeros == []:
             if (
                 "counts" not in stage.input_units.lower()
@@ -137,18 +136,20 @@ def create_filter_from_stage(stage):
                 return create_coefficent_filter_from_stage(stage)
 
         return create_pole_zero_filter_from_stage(stage)
+    except AttributeError:
+        pass
 
-    elif isinstance(
-        stage, obspy.core.inventory.response.CoefficientsTypeResponseStage
-    ):
+    try:
         is_a_delay_filter = check_if_coefficient_filter_is_delay_only(stage)
         if is_a_delay_filter:
             obspy_filter = create_time_delay_filter_from_stage(stage)
         else:
             obspy_filter = create_coefficent_filter_from_stage(stage)
         return obspy_filter
+    except AttributeError:
+        pass
 
-    elif isinstance(stage, obspy.core.inventory.response.FIRResponseStage):
+    try:
         try:
             if isinstance(stage.coefficients, list):
                 pass
@@ -162,18 +163,22 @@ def create_filter_from_stage(stage):
             raise ValueError(msg)
         obspy_filter = create_fir_filter_from_stage(stage)
         return obspy_filter
+    except AttributeError:
+        pass
 
-    elif isinstance(
-        stage, obspy.core.inventory.response.ResponseListResponseStage
-    ):
+    try:
         obspy_filter = create_frequency_response_table_filter_from_stage(stage)
         return obspy_filter
+    except AttributeError:
+        pass
 
-    elif isinstance(stage, obspy.core.inventory.response.ResponseStage):
+    try:
         obspy_filter = create_coefficent_filter_from_stage(stage)
         return obspy_filter
+    except AttributeError:
+        pass
 
     else:
-        msg = "Filter Stage of type {type(stage)} not known, or supported"
+        msg = f"Filter Stage of type {type(stage)} not known, or supported"
         logger.info(msg)
         raise TypeError(msg)

--- a/mt_metadata/timeseries/filters/obspy_stages.py
+++ b/mt_metadata/timeseries/filters/obspy_stages.py
@@ -6,6 +6,10 @@ Idea here is to add logic to interrogate stage filters received from StationXML
 # Imports
 # =============================================================================
 import numpy as np
+try:
+    import obspy
+except ImportError:
+    raise ImportError("obspy_stages requires obspy to be installed.")
 from loguru import logger
 
 from mt_metadata.timeseries.filters import (
@@ -123,7 +127,7 @@ def create_filter_from_stage(stage):
 
     """
 
-    try:
+    if isinstance(stage, obspy.core.inventory.response.PolesZerosResponseStage):
         if stage.poles == [] and stage.zeros == []:
             if (
                 "counts" not in stage.input_units.lower()
@@ -136,20 +140,18 @@ def create_filter_from_stage(stage):
                 return create_coefficent_filter_from_stage(stage)
 
         return create_pole_zero_filter_from_stage(stage)
-    except AttributeError:
-        pass
 
-    try:
+    elif isinstance(
+        stage, obspy.core.inventory.response.CoefficientsTypeResponseStage
+    ):
         is_a_delay_filter = check_if_coefficient_filter_is_delay_only(stage)
         if is_a_delay_filter:
             obspy_filter = create_time_delay_filter_from_stage(stage)
         else:
             obspy_filter = create_coefficent_filter_from_stage(stage)
         return obspy_filter
-    except AttributeError:
-        pass
 
-    try:
+    elif isinstance(stage, obspy.core.inventory.response.FIRResponseStage):
         try:
             if isinstance(stage.coefficients, list):
                 pass
@@ -163,22 +165,18 @@ def create_filter_from_stage(stage):
             raise ValueError(msg)
         obspy_filter = create_fir_filter_from_stage(stage)
         return obspy_filter
-    except AttributeError:
-        pass
 
-    try:
+    elif isinstance(
+        stage, obspy.core.inventory.response.ResponseListResponseStage
+    ):
         obspy_filter = create_frequency_response_table_filter_from_stage(stage)
         return obspy_filter
-    except AttributeError:
-        pass
 
-    try:
+    elif isinstance(stage, obspy.core.inventory.response.ResponseStage):
         obspy_filter = create_coefficent_filter_from_stage(stage)
         return obspy_filter
-    except AttributeError:
-        pass
 
     else:
-        msg = f"Filter Stage of type {type(stage)} not known, or supported"
+        msg = "Filter Stage of type {type(stage)} not known, or supported"
         logger.info(msg)
         raise TypeError(msg)

--- a/mt_metadata/timeseries/filters/pole_zero_filter.py
+++ b/mt_metadata/timeseries/filters/pole_zero_filter.py
@@ -7,12 +7,15 @@
 
 """
 import numpy as np
-import obspy
+try:
+    import obspy
+except ImportError:
+    obspy = None
 import scipy.signal as signal
 
 from mt_metadata.base import get_schema
-from mt_metadata.timeseries.filters.filter_base import FilterBase
-from mt_metadata.timeseries.filters.filter_base import get_base_obspy_mapping
+from mt_metadata.base.helpers import requires
+from mt_metadata.timeseries.filters.filter_base import FilterBase, get_base_obspy_mapping
 from mt_metadata.timeseries.filters.standards import SCHEMA_FN_PATHS
 
 # =============================================================================
@@ -29,7 +32,6 @@ class PoleZeroFilter(FilterBase):
 
         super(FilterBase, self).__init__(attr_dict=attr_dict, **kwargs)
         self.type = "zpk"
-
 
     def make_obspy_mapping(self):
         mapping = get_base_obspy_mapping()
@@ -134,6 +136,7 @@ class PoleZeroFilter(FilterBase):
         """
         return self.gain * self.normalization_factor
 
+    @requires(obspy=obspy)
     def to_obspy(
         self,
         stage_number=1,

--- a/mt_metadata/timeseries/filters/time_delay_filter.py
+++ b/mt_metadata/timeseries/filters/time_delay_filter.py
@@ -9,7 +9,13 @@
 """
 
 import numpy as np
-from obspy.core import inventory
+
+from mt_metadata.base.helpers import requires
+
+try:
+    from obspy.core import inventory
+except ImportError:
+    inventory = None
 
 from mt_metadata.base import get_schema
 from mt_metadata.timeseries.filters.filter_base import FilterBase
@@ -35,6 +41,7 @@ class TimeDelayFilter(FilterBase):
         mapping["decimation_delay"] = "delay"
         return mapping
 
+    @requires(obspy=inventory)
     def to_obspy(self, stage_number=1, sample_rate=1, normalization_frequency=0):
         """
         Convert to an obspy stage

--- a/mt_metadata/timeseries/stationxml/__init__.py
+++ b/mt_metadata/timeseries/stationxml/__init__.py
@@ -3,6 +3,11 @@
 Tools to translate StationXML to MT Metadata
 """
 
+try:
+    import obspy
+except ImportError:
+    raise ImportError("StationXML requires obspy to be installed.")
+
 from .xml_network_mt_survey import XMLNetworkMTSurvey
 from .xml_equipment_mt_run import XMLEquipmentMTRun
 from .xml_station_mt_station import XMLStationMTStation

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -24,7 +24,7 @@ DATETIME_HINT = Union[
     np.datetime64,
     pd.Timestamp,
     str,
-    datetime,
+    datetime.datetime,
 ]
 
 try:

--- a/mt_metadata/utils/mttime.py
+++ b/mt_metadata/utils/mttime.py
@@ -13,10 +13,25 @@ from dateutil.parser import parse as dtparser
 import numpy as np
 import pandas as pd
 from pandas._libs.tslibs import OutOfBoundsDatetime
-from obspy.core.utcdatetime import UTCDateTime  # for type hinting
+
 from typing import Optional, Union  # Self is importable in python 3.11+
 
 from loguru import logger
+
+DATETIME_HINT = Union[
+    float,
+    int,
+    np.datetime64,
+    pd.Timestamp,
+    str,
+    datetime,
+]
+
+try:
+    from obspy.core.utcdatetime import UTCDateTime  # for type hinting
+    DATETIME_HINT = Union[DATETIME_HINT, UTCDateTime]
+except ImportError:
+    pass
 
 # =============================================================================
 #  Get leap seconds
@@ -390,16 +405,7 @@ class MTime:
 
     def parse(
         self,
-        dt_str: Optional[
-            Union[
-                float,
-                int,
-                np.datetime64,
-                pd.Timestamp,
-                str,
-                UTCDateTime
-            ]
-        ] = None
+        dt_str: Optional[DATETIME_HINT] = None
     ) -> None:  # TODO: add Self as s typehint 3.11
         """
         Parse a date-time string using dateutil.parser

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,15 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "numpy",
     "pandas",
-    "obspy",
     "matplotlib",
     "xarray",
     "loguru",
 ]
 
-setup_requirements = [
-    "pytest-runner",
-]
-
-test_requirements = [
-    "pytest>=3",
-]
+extras_require = {
+        'obspy': ["obspy"],
+        'test': ["pytest>=3"]
+}
 
 setup(
     author="Jared Peacock",
@@ -52,9 +48,7 @@ setup(
     keywords="mt_metadata",
     name="mt_metadata",
     packages=find_packages(include=["mt_metadata", "mt_metadata.*"]),
-    setup_requires=setup_requirements,
     test_suite="tests",
-    tests_require=test_requirements,
     url="https://github.com/kujaku11/mt_metadata",
     version="0.3.9",
     zip_safe=False,
@@ -65,4 +59,5 @@ setup(
             "data/transfer_functions/*.edi",
         ]
     },
+    extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "numpy",
+    "scipy",
     "pandas",
     "matplotlib",
     "xarray",

--- a/tests/test_mttime.py
+++ b/tests/test_mttime.py
@@ -8,6 +8,7 @@ Created on Thu May 21 14:09:17 2020
 # Imports
 # =============================================================================
 import unittest
+import pytest
 from dateutil import parser as dtparser
 from dateutil import tz
 import datetime
@@ -15,7 +16,10 @@ import pandas as pd
 import numpy as np
 
 from mt_metadata.utils.mttime import MTime
-from obspy import UTCDateTime
+try:
+    from obspy import UTCDateTime
+except ImportError:
+    UTCDateTime = None
 
 
 # =============================================================================
@@ -177,6 +181,7 @@ class TestMTime(unittest.TestCase):
                 self.epoch_seconds, t.epoch_seconds, places=4
             )
 
+    @pytest.mark.skipif(UTCDateTime is None, reason="obspy is not installed.")
     def test_obspy_utcdatetime(self):
         t = MTime(UTCDateTime(self.dt_true))
 
@@ -290,10 +295,12 @@ class TestMTime(unittest.TestCase):
         t1 = MTime("1400-01-01T00:00:00")
         self.assertEqual(t1, pd.Timestamp.min)
 
+    @pytest.mark.skipif(UTCDateTime is None, reason="obspy is not installed.")
     def test_utc_too_large(self):
         t1 = MTime(UTCDateTime("3000-01-01"))
         self.assertEqual(t1, pd.Timestamp.max)
 
+    @pytest.mark.skipif(UTCDateTime is None, reason="obspy is not installed.")
     def test_utc_too_small(self):
         t1 = MTime(UTCDateTime("1400-01-01"))
         self.assertEqual(t1, pd.Timestamp.min)

--- a/tests/timeseries/filters/test_channel_response.py
+++ b/tests/timeseries/filters/test_channel_response.py
@@ -16,9 +16,6 @@ from mt_metadata.timeseries.filters import (
     ChannelResponse,
     TimeDelayFilter,
 )
-from mt_metadata.utils.exceptions import MTSchemaError
-
-from obspy.core.inventory.response import ResponseListResponseStage
 
 
 class TestFAPFilter(unittest.TestCase):

--- a/tests/timeseries/filters/test_coefficient_filter.py
+++ b/tests/timeseries/filters/test_coefficient_filter.py
@@ -6,15 +6,17 @@ Created on Sat Nov 20 17:13:27 2021
 """
 
 import unittest
+import pytest
+try:
+    import obspy
+except ImportError:
+    obspy = None
 
 import numpy as np
 
 from mt_metadata.timeseries.filters import CoefficientFilter
-from mt_metadata.timeseries.filters.helper_functions import MT2SI_ELECTRIC_FIELD_FILTER
 from mt_metadata.timeseries.filters.helper_functions import MT2SI_MAGNETIC_FIELD_FILTER
 from mt_metadata.utils.exceptions import MTSchemaError
-
-from obspy.core.inventory.response import CoefficientsTypeResponseStage
 
 
 class TestCoefficientFilter(unittest.TestCase):
@@ -60,6 +62,7 @@ class TestCoefficientFilter(unittest.TestCase):
             phase = np.repeat(0, self.f.size)
             self.assertTrue(np.isclose(cr_phase, phase).all() == True)
 
+    @pytest.mark.skipif(obspy is None, reason="obspy is not installed.")
     def test_to_obspy_stage(self):
         stage = self.cf.to_obspy(2, sample_rate=10, normalization_frequency=1)
 

--- a/tests/timeseries/filters/test_electric_unit.py
+++ b/tests/timeseries/filters/test_electric_unit.py
@@ -23,7 +23,11 @@ Notes:
 
 """
 import unittest
-from obspy.core import inventory
+import pytest
+try:
+    from obspy.core import inventory
+except ImportError:
+    pytest.skip("obspy is not installed.", allow_module_level=True)
 
 from mt_metadata.timeseries.filters import (
     ChannelResponse,

--- a/tests/timeseries/filters/test_electric_unit.py
+++ b/tests/timeseries/filters/test_electric_unit.py
@@ -26,6 +26,7 @@ import unittest
 import pytest
 try:
     from obspy.core import inventory
+    from mt_metadata.timeseries.filters.obspy_stages import create_filter_from_stage
 except ImportError:
     pytest.skip("obspy is not installed.", allow_module_level=True)
 
@@ -36,7 +37,6 @@ from mt_metadata.timeseries.filters import (
     TimeDelayFilter,
 )
 from mt_metadata import STATIONXML_ELECTRIC
-from mt_metadata.timeseries.filters.obspy_stages import create_filter_from_stage
 
 
 class TestFilterElectric(unittest.TestCase):

--- a/tests/timeseries/filters/test_fap_filter.py
+++ b/tests/timeseries/filters/test_fap_filter.py
@@ -8,11 +8,15 @@ import pathlib
 import unittest
 
 import numpy as np
+import pytest
 
 from mt_metadata.timeseries.filters import FrequencyResponseTableFilter
 from mt_metadata.utils.exceptions import MTSchemaError
 
-from obspy.core.inventory.response import ResponseListResponseStage
+try:
+    from obspy.core.inventory.response import ResponseListResponseStage
+except ImportError:
+    ResponseListResponseStage = None
 
 
 class TestFAPFilter(unittest.TestCase):
@@ -228,6 +232,7 @@ class TestFAPFilter(unittest.TestCase):
                 np.isclose(cr_phase[:-10], self.fap.phases[:-10]).all()
             )
 
+    @pytest.mark.skipif(ResponseListResponseStage is None, reason="obspy is not installed.")
     def test_to_obspy_stage(self):
         stage = self.fap.to_obspy(2, sample_rate=10, normalization_frequency=1)
 

--- a/tests/timeseries/filters/test_filter_base.py
+++ b/tests/timeseries/filters/test_filter_base.py
@@ -6,6 +6,11 @@ Created on Fri Nov 19 18:45:48 2021
 """
 
 import unittest
+import pytest
+try:
+    import obspy
+except ImportError:
+    obspy = None
 from mt_metadata.timeseries.filters.filter_base import FilterBase
 
 
@@ -61,6 +66,7 @@ class TestFilterBase(unittest.TestCase):
             fb = FilterBase(gain=0.0)
             self.assertEqual(1, fb.gain)
 
+    @pytest.mark.skipif(obspy is None, reason="obspy is not installed.")
     def test_obspy_map(self):
         default_obspy_map = self.fb.obspy_mapping
         self.assertIsNotNone(default_obspy_map)

--- a/tests/timeseries/filters/test_magnetic_unit.py
+++ b/tests/timeseries/filters/test_magnetic_unit.py
@@ -36,6 +36,7 @@ import unittest
 import pytest
 try:
     from obspy.core import inventory
+    from mt_metadata.timeseries.filters.obspy_stages import create_filter_from_stage
 except ImportError:
     pytest.skip("obspy is not installed.", allow_module_level=True)
 
@@ -46,7 +47,6 @@ from mt_metadata.timeseries.filters import (
     TimeDelayFilter,
 )
 from mt_metadata import STATIONXML_MAGNETIC
-from mt_metadata.timeseries.filters.obspy_stages import create_filter_from_stage
 
 
 class TestFilterMagnetic(unittest.TestCase):

--- a/tests/timeseries/filters/test_magnetic_unit.py
+++ b/tests/timeseries/filters/test_magnetic_unit.py
@@ -33,7 +33,11 @@ ToDo:
 
 """
 import unittest
-from obspy.core import inventory
+import pytest
+try:
+    from obspy.core import inventory
+except ImportError:
+    pytest.skip("obspy is not installed.", allow_module_level=True)
 
 from mt_metadata.timeseries.filters import (
     ChannelResponse,

--- a/tests/timeseries/filters/test_time_delay_filter.py
+++ b/tests/timeseries/filters/test_time_delay_filter.py
@@ -6,13 +6,17 @@ Created on Sat Nov 20 17:13:27 2021
 """
 
 import unittest
+import pytest
 
 import numpy as np
 
 from mt_metadata.timeseries.filters import TimeDelayFilter
 from mt_metadata.utils.exceptions import MTSchemaError
 
-from obspy.core.inventory.response import CoefficientsTypeResponseStage
+try:
+    from obspy.core.inventory.response import CoefficientsTypeResponseStage
+except ImportError:
+    CoefficientsTypeResponseStage = None
 
 
 class TestTimeDelayFilter(unittest.TestCase):
@@ -62,6 +66,7 @@ class TestTimeDelayFilter(unittest.TestCase):
         pb = self.td.pass_band(self.f)
         self.assertTrue(np.isclose(pb, np.array([self.f.min(), self.f.max()])).all())
 
+    @pytest.mark.skipif(CoefficientsTypeResponseStage is None, reason="obspy is not installed.")
     def test_to_obspy_stage(self):
         stage = self.td.to_obspy(2, sample_rate=10, normalization_frequency=1)
 

--- a/tests/timeseries/filters/test_zpk_filter.py
+++ b/tests/timeseries/filters/test_zpk_filter.py
@@ -6,13 +6,17 @@ Created on Sat Nov 20 17:13:27 2021
 """
 
 import unittest
+import pytest
 
 import numpy as np
 
 from mt_metadata.timeseries.filters import PoleZeroFilter
 from mt_metadata.utils.exceptions import MTSchemaError
 
-from obspy.core.inventory.response import PolesZerosResponseStage
+try:
+    from obspy.core.inventory.response import PolesZerosResponseStage
+except ImportError:
+    PolesZerosResponseStage = None
 
 
 class TestZPKFilter(unittest.TestCase):
@@ -86,6 +90,7 @@ class TestZPKFilter(unittest.TestCase):
             )
             self.assertTrue(abs(slope) < 1)
 
+    @pytest.mark.skipif(PolesZerosResponseStage is None, reason="obspy is not installed.")
     def test_to_obspy_stage(self):
         stage = self.pz.to_obspy(2, sample_rate=10, normalization_frequency=1)
 

--- a/tests/timeseries/stationxml/test_base_translator.py
+++ b/tests/timeseries/stationxml/test_base_translator.py
@@ -2,7 +2,7 @@
 """
 Created on Thu Feb 18 16:33:42 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -10,8 +10,12 @@ Created on Thu Feb 18 16:33:42 2021
 """
 
 import unittest
-from mt_metadata.timeseries.stationxml.utils import BaseTranslator
-from obspy.core.inventory import Comment
+import pytest
+try:
+    from mt_metadata.timeseries.stationxml.utils import BaseTranslator
+    from obspy.core.inventory import Comment
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 
 
 class TestReadXMLComment(unittest.TestCase):

--- a/tests/timeseries/stationxml/test_channel.py
+++ b/tests/timeseries/stationxml/test_channel.py
@@ -17,13 +17,14 @@ from collections import OrderedDict
 
 try:
     from obspy import read_inventory
+    from mt_metadata.timeseries.filters.obspy_stages import (
+        create_filter_from_stage,
+    )
 except ImportError:
     pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLChannelMTChannel
 from mt_metadata import STATIONXML_01, STATIONXML_02
-from mt_metadata.timeseries.filters.obspy_stages import (
-    create_filter_from_stage,
-)
+
 
 # =============================================================================
 

--- a/tests/timeseries/stationxml/test_channel.py
+++ b/tests/timeseries/stationxml/test_channel.py
@@ -12,9 +12,13 @@ Created on Sun Feb 21 15:17:41 2021
 # Imports
 # =============================================================================
 import unittest
+import pytest
 from collections import OrderedDict
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLChannelMTChannel
 from mt_metadata import STATIONXML_01, STATIONXML_02
 from mt_metadata.timeseries.filters.obspy_stages import (

--- a/tests/timeseries/stationxml/test_experiment_to_stationxml.py
+++ b/tests/timeseries/stationxml/test_experiment_to_stationxml.py
@@ -2,7 +2,7 @@
 """
 Created on Tue Feb 23 23:13:19 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -12,9 +12,13 @@ Created on Tue Feb 23 23:13:19 2021
 # Imports
 # =============================================================================
 import unittest
+import pytest
 
 from mt_metadata.timeseries import Experiment
-from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+try:
+    from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata import (
     MT_EXPERIMENT_MULTIPLE_RUNS,
     MT_EXPERIMENT_MULTIPLE_RUNS_02,

--- a/tests/timeseries/stationxml/test_fap.py
+++ b/tests/timeseries/stationxml/test_fap.py
@@ -5,8 +5,13 @@ Test FAP tables
 
 """
 import unittest
+import pytest
 import numpy as np
-from obspy.core import inventory
+
+try:
+    from obspy.core import inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 
 from mt_metadata.timeseries.filters import FrequencyResponseTableFilter
 from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment

--- a/tests/timeseries/stationxml/test_fap.py
+++ b/tests/timeseries/stationxml/test_fap.py
@@ -10,15 +10,15 @@ import numpy as np
 
 try:
     from obspy.core import inventory
+    from mt_metadata.timeseries.filters.obspy_stages import (
+        create_filter_from_stage,
+    )
 except ImportError:
     pytest.skip(reason="obspy is not installed", allow_module_level=True)
 
 from mt_metadata.timeseries.filters import FrequencyResponseTableFilter
 from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
 from mt_metadata import STATIONXML_FAP
-from mt_metadata.timeseries.filters.obspy_stages import (
-    create_filter_from_stage,
-)
 
 
 class TestFAPFilter(unittest.TestCase):
@@ -41,6 +41,8 @@ class TestFAPFilter(unittest.TestCase):
             .channels[0]
             .response.instrument_sensitivity
         )
+        print(type(self.fir_stage))
+        print(self.fir_stage)
         self.fir = create_filter_from_stage(self.fir_stage)
 
     def test_is_fap_instance(self):

--- a/tests/timeseries/stationxml/test_fdsn_tools.py
+++ b/tests/timeseries/stationxml/test_fdsn_tools.py
@@ -2,7 +2,7 @@
 """
 Created on Sat Feb 20 16:23:12 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -10,8 +10,11 @@ Created on Sat Feb 20 16:23:12 2021
 """
 
 import unittest
-
-from mt_metadata.timeseries.stationxml import fdsn_tools
+import pytest
+try:
+    from mt_metadata.timeseries.stationxml import fdsn_tools
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 
 
 class TestOrientationCode(unittest.TestCase):

--- a/tests/timeseries/stationxml/test_inventory.py
+++ b/tests/timeseries/stationxml/test_inventory.py
@@ -2,7 +2,7 @@
 """
 Created on Tue Feb 23 23:13:19 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -12,8 +12,12 @@ Created on Tue Feb 23 23:13:19 2021
 # Imports
 # =============================================================================
 import unittest
+import pytest
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
 from mt_metadata import (
     STATIONXML_01,

--- a/tests/timeseries/stationxml/test_network.py
+++ b/tests/timeseries/stationxml/test_network.py
@@ -2,7 +2,7 @@
 """
 Created on Tue Feb 16 11:58:11 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -10,8 +10,12 @@ Created on Tue Feb 16 11:58:11 2021
 """
 
 import unittest
+import pytest
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import xml_network_mt_survey
 from mt_metadata import STATIONXML_01, STATIONXML_02
 

--- a/tests/timeseries/stationxml/test_renaming_filters.py
+++ b/tests/timeseries/stationxml/test_renaming_filters.py
@@ -9,10 +9,14 @@ Created on Fri Oct 14 15:39:41 2022
 # Imports
 # =============================================================================
 import unittest
+import pytest
 from collections import OrderedDict
 import numpy as np
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLChannelMTChannel
 from mt_metadata import STATIONXML_01
 from mt_metadata.timeseries.filters import PoleZeroFilter

--- a/tests/timeseries/stationxml/test_run.py
+++ b/tests/timeseries/stationxml/test_run.py
@@ -2,7 +2,7 @@
 """
 Created on Thu Feb 18 18:36:41 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -10,8 +10,12 @@ Created on Thu Feb 18 18:36:41 2021
 """
 
 import unittest
+import pytest
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLEquipmentMTRun
 from mt_metadata import STATIONXML_02
 

--- a/tests/timeseries/stationxml/test_station.py
+++ b/tests/timeseries/stationxml/test_station.py
@@ -2,7 +2,7 @@
 """
 Created on Tue Feb 16 11:58:11 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -12,9 +12,13 @@ Created on Tue Feb 16 11:58:11 2021
 # Imports
 # =============================================================================
 import unittest
+import pytest
 from collections import OrderedDict
 
-from obspy import read_inventory
+try:
+    from obspy import read_inventory
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata.timeseries.stationxml import XMLStationMTStation
 from mt_metadata import STATIONXML_01, STATIONXML_02
 

--- a/tests/timeseries/stationxml/test_translations_electric.py
+++ b/tests/timeseries/stationxml/test_translations_electric.py
@@ -4,7 +4,7 @@ Test translation from xml to mtml back to xml
 
 Created on Fri Mar 26 08:15:49 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -14,7 +14,11 @@ Created on Fri Mar 26 08:15:49 2021
 # Imports
 # =============================================================================
 import unittest
-from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+import pytest
+try:
+    from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata import STATIONXML_ELECTRIC
 from obspy.core import inventory
 

--- a/tests/timeseries/stationxml/test_translations_magnetic.py
+++ b/tests/timeseries/stationxml/test_translations_magnetic.py
@@ -4,7 +4,7 @@ Test translation from xml to mtml back to xml
 
 Created on Fri Mar 26 08:15:49 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -14,7 +14,11 @@ Created on Fri Mar 26 08:15:49 2021
 # Imports
 # =============================================================================
 import unittest
-from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+import pytest
+try:
+    from mt_metadata.timeseries.stationxml import XMLInventoryMTExperiment
+except ImportError:
+    pytest.skip(reason="obspy is not installed", allow_module_level=True)
 from mt_metadata import STATIONXML_MAGNETIC
 from obspy.core import inventory
 


### PR DESCRIPTION
First of all let me know if this isn't welcome, no hard feelings here :).

I was running into issues getting `mt_metadata` installed into in my "everyday" `conda` environment, and it was due to `obspy` not providing a `numpy` 2.0 compatible release yet. So I went looking into `mt_metadata`'s requirements. It didn't immediately appear that `obspy` was providing any sort of "core" functionality to `mt_metadata` and was only imported for translating between the two packages (i.e. `to_obspy` and `from_obspy` related functions), and for making use of their `StationXML` reader.

The proposed changes do a few things to avoid importing `obspy`:
* `from_obspy` like functions are now wrapped in `try: ... except AttributeError: ...` blocks (essentially treating this as duck typing allowing anything that "looks" like the expected type to also work).
* `to_obspy` functions are wrapped by a `requires` decorator that will inform the user that the functionality requires `obspy` to be installed if it is not.
* For the StationXML functionality, it is blocked at the base load step informing users when attempting to import from that package.
* Uses `pytest`'s skipping functionality to skip tests that require `obspy`.
* Updates the setup.py requirements.
    * I also took the liberty of removing `pytest-runner` as well since it is deprecated: See [pytest-runner docs](https://pypi.org/project/pytest-runner)