### PR TITLE
Map DOI vs URL correctly in EDI survey metadata

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Changelog
 =========
 
 All notable changes to this project will be documented in this file.
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
 History
 =========
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mt_metadata version 1.0.8
+# mt_metadata version 1.0.9
  Standard MT metadata
 
 [![PyPi version](https://img.shields.io/pypi/v/mt_metadata.svg)](https://pypi.python.org/pypi/mt-metadata)
@@ -28,7 +28,7 @@ MT Metadata is a project led by [IRIS-PASSCAL MT Software working group](https:/
 
 Most people will be using the transfer functions, but a lot of that metadata comes from the time series metadata.  This module supports both and has tried to make them more or less seamless to reduce complication.
 
-* **Version**: 1.0.8
+* **Version**: 1.0.9
 * **Free software**: MIT license
 * **Documentation**: https://mt-metadata.readthedocs.io.
 * **Examples**: Click the `Binder` badge above and Jupyter Notebook examples are in **mt_metadata/examples/notebooks** and **docs/source/notebooks**

--- a/code.json
+++ b/code.json
@@ -3,20 +3,20 @@
     "name": "mt-metadata",
     "organization": "U.S. Geological Survey",
     "description": "A Python module to handle/validate/read/write metadata in general but mainly for magnetotelluric data including time series, transfer functions, and Fourier coefficients. Formats include JSON, XML, text files.",
-    "version": "v1.0.8",
+    "version": "v1.0.9",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",
       "licenses": [
         {
           "name": "MIT",
-          "URL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.8/LICENSE.md"
+          "URL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.9/LICENSE.md"
         }
       ]
     },
     "homepageURL": "https://code.usgs.gov/gmeg/mt_metadata",
-    "downloadURL": "https://code.usgs.gov/gmeg/mt-metadata/-/archive/v1.0.8/mt-metadata-v1.0.8.zip",
-    "disclaimerURL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.8/DISCLAIMER.md",
+    "downloadURL": "https://code.usgs.gov/gmeg/mt-metadata/-/archive/v1.0.9/mt-metadata-v1.0.9.zip",
+    "disclaimerURL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.9/DISCLAIMER.md",
     "repositoryURL": "https://code.usgs.gov/gmeg/mt_metadata.git",
     "tags": [
       "magnetotellurics",

--- a/mt_metadata/__init__.py
+++ b/mt_metadata/__init__.py
@@ -39,7 +39,7 @@ you should only have to changes these dictionaries.
 
 __author__ = """Jared Peacock"""
 __email__ = "jpeacock@usgs.gov"
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 # =============================================================================
 # Imports

--- a/mt_metadata/transfer_functions/io/edi/edi.py
+++ b/mt_metadata/transfer_functions/io/edi/edi.py
@@ -20,6 +20,7 @@ from typing import Literal
 
 import numpy as np
 from loguru import logger
+from pydantic import HttpUrl
 
 from mt_metadata import __version__, NULL_VALUES
 from mt_metadata.timeseries import Electric, Magnetic, Run, Survey
@@ -36,7 +37,7 @@ from mt_metadata.transfer_functions.io.tools import (
     get_nm_elev,
     index_locator,
 )
-from mt_metadata.utils.validators import validate_station_name
+from mt_metadata.utils.validators import validate_doi, validate_station_name
 
 
 # ==============================================================================
@@ -993,9 +994,9 @@ class EDI:
                 key = "extra"
             key = key.lower()
             if key.startswith("survey."):
-                if "doi" in key:
-                    if "doi" not in value:
-                        key = key.replace("doi", "url")
+                if "doi" in key and not self._is_doi_value(value):
+                    key = key.replace("doi", "url")
+
                 try:
                     sm.update_attribute(key.split("survey.")[1], value)
                 except Exception as error:
@@ -1006,6 +1007,17 @@ class EDI:
         sm.add_station(self.station_metadata)
 
         return sm
+
+    @staticmethod
+    def _is_doi_value(value: str | HttpUrl | object) -> bool:
+        """Return True when the value can be validated as a DOI."""
+        if not isinstance(value, (str, HttpUrl)):
+            return False
+
+        try:
+            return validate_doi(value) is not None
+        except (TypeError, ValueError):
+            return False
 
     @survey_metadata.setter
     def survey_metadata(self, survey: Survey) -> None:
@@ -1109,9 +1121,9 @@ class EDI:
                             sm.transfer_function.remote_references.append(value)
                         elif key in ["remote_references.geographic_name"]:
                             try:
-                                sm.transfer_function.remote_references[-1] = (
-                                    f"{value}.{sm.transfer_function.remote_references[-1]}"
-                                )
+                                sm.transfer_function.remote_references[
+                                    -1
+                                ] = f"{value}.{sm.transfer_function.remote_references[-1]}"
                             except IndexError:
                                 sm.transfer_function.remote_references.append(value)
                         else:
@@ -1290,9 +1302,9 @@ class EDI:
                     if ch_key not in self._channel_skip_list:
                         if ch_value in NULL_VALUES:
                             continue
-                        self.Info.info_dict[f"{run.id}.{ch.component}.{ch_key}"] = (
-                            ch_value
-                        )
+                        self.Info.info_dict[
+                            f"{run.id}.{ch.component}.{ch_key}"
+                        ] = ch_value
                 # write station information
                 self.Measurement.from_metadata(ch)
                 # add channel id to data section

--- a/mt_metadata/transfer_functions/io/edi/edi.py
+++ b/mt_metadata/transfer_functions/io/edi/edi.py
@@ -1121,9 +1121,9 @@ class EDI:
                             sm.transfer_function.remote_references.append(value)
                         elif key in ["remote_references.geographic_name"]:
                             try:
-                                sm.transfer_function.remote_references[
-                                    -1
-                                ] = f"{value}.{sm.transfer_function.remote_references[-1]}"
+                                sm.transfer_function.remote_references[-1] = (
+                                    f"{value}.{sm.transfer_function.remote_references[-1]}"
+                                )
                             except IndexError:
                                 sm.transfer_function.remote_references.append(value)
                         else:
@@ -1302,9 +1302,9 @@ class EDI:
                     if ch_key not in self._channel_skip_list:
                         if ch_value in NULL_VALUES:
                             continue
-                        self.Info.info_dict[
-                            f"{run.id}.{ch.component}.{ch_key}"
-                        ] = ch_value
+                        self.Info.info_dict[f"{run.id}.{ch.component}.{ch_key}"] = (
+                            ch_value
+                        )
                 # write station information
                 self.Measurement.from_metadata(ch)
                 # add channel id to data section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mt_metadata"
-version = "1.0.8"
+version = "1.0.9"
 description = "Metadata for magnetotelluric data"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
@@ -98,7 +98,7 @@ ignore-init-module-imports = true
 in-place = true
 
 [tool.bumpversion]
-current_version = "1.0.8"
+current_version = "1.0.9"
 commit = true
 tag = true
 

--- a/tests/transfer_functions/io/edi/test_edi.py
+++ b/tests/transfer_functions/io/edi/test_edi.py
@@ -11,9 +11,11 @@ import numpy as np
 #
 # =============================================================================
 import pytest
+from pydantic import HttpUrl
 
 from mt_metadata.transfer_functions.io.edi import EDI
 from mt_metadata.transfer_functions.io.edi.metadata import EMeasurement, HMeasurement
+from mt_metadata.utils.validators import validate_doi
 
 
 # =============================================================================
@@ -162,6 +164,42 @@ class TestAssertDescendingFrequency:
         assert np.allclose(
             expected_array, actual_array
         ), f"{array_type} array not properly reversed"
+
+
+class TestSurveyMetadataDoiHandling:
+    """Test mapping survey DOI keys to DOI or URL fields."""
+
+    @pytest.mark.parametrize(
+        "value, expected_field",
+        [
+            ("https://doi.org/10.1234/test", "citation_dataset.doi"),
+            ("10.1234/test", "citation_dataset.doi"),
+            ("doi:10.1234/test", "citation_dataset.doi"),
+            ("https://example.com/dataset", "citation_dataset.url"),
+            (HttpUrl("https://doi.org/10.1234/test"), "citation_dataset.doi"),
+            (HttpUrl("https://example.com/dataset"), "citation_dataset.url"),
+        ],
+    )
+    def test_survey_doi_values_map_to_expected_field(self, value, expected_field):
+        edi = EDI()
+        edi.Info.info_dict["survey.citation_dataset.doi"] = value
+
+        survey_metadata = edi.survey_metadata
+        actual_value = survey_metadata.get_attr_from_name(expected_field)
+
+        if expected_field.endswith("doi"):
+            assert actual_value.unicode_string() == validate_doi(value).unicode_string()
+        elif isinstance(value, HttpUrl):
+            assert actual_value.unicode_string() == value.unicode_string()
+        else:
+            assert actual_value == value
+
+        other_field = (
+            "citation_dataset.url"
+            if expected_field.endswith("doi")
+            else "citation_dataset.doi"
+        )
+        assert survey_metadata.get_attr_from_name(other_field) in [None, "None"]
 
 
 # =============================================================================


### PR DESCRIPTION
Add DOI validation and HttpUrl support to EDI parsing so survey citation values are mapped to citation_dataset.doi only when they validate as a DOI; otherwise they are mapped to citation_dataset.url. Introduces a private _is_doi_value helper that accepts str or pydantic.HttpUrl and uses validate_doi, updates imports, and simplifies the key-handling logic. Adds tests (TestSurveyMetadataDoiHandling) covering string and HttpUrl DOI/URL cases and asserting the alternate field remains empty.