### PR TITLE
EMTFXML updates

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
     paths:
       - '**.py'
+      
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   format:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish to PyPI
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,10 @@ Changelog
 =========
 
 All notable changes to this project will be documented in this file.
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
 History
 =========
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mt_metadata version 1.0.9
+# mt_metadata version 1.0.10
  Standard MT metadata
 
 [![PyPi version](https://img.shields.io/pypi/v/mt_metadata.svg)](https://pypi.python.org/pypi/mt-metadata)
@@ -28,7 +28,7 @@ MT Metadata is a project led by [IRIS-PASSCAL MT Software working group](https:/
 
 Most people will be using the transfer functions, but a lot of that metadata comes from the time series metadata.  This module supports both and has tried to make them more or less seamless to reduce complication.
 
-* **Version**: 1.0.9
+* **Version**: 1.0.10
 * **Free software**: MIT license
 * **Documentation**: https://mt-metadata.readthedocs.io.
 * **Examples**: Click the `Binder` badge above and Jupyter Notebook examples are in **mt_metadata/examples/notebooks** and **docs/source/notebooks**

--- a/code.json
+++ b/code.json
@@ -3,20 +3,20 @@
     "name": "mt-metadata",
     "organization": "U.S. Geological Survey",
     "description": "A Python module to handle/validate/read/write metadata in general but mainly for magnetotelluric data including time series, transfer functions, and Fourier coefficients. Formats include JSON, XML, text files.",
-    "version": "v1.0.9",
+    "version": "v1.0.10",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",
       "licenses": [
         {
           "name": "MIT",
-          "URL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.9/LICENSE.md"
+          "URL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.10/LICENSE.md"
         }
       ]
     },
     "homepageURL": "https://code.usgs.gov/gmeg/mt_metadata",
-    "downloadURL": "https://code.usgs.gov/gmeg/mt-metadata/-/archive/v1.0.9/mt-metadata-v1.0.9.zip",
-    "disclaimerURL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.9/DISCLAIMER.md",
+    "downloadURL": "https://code.usgs.gov/gmeg/mt-metadata/-/archive/v1.0.10/mt-metadata-v1.0.10.zip",
+    "disclaimerURL": "https://code.usgs.gov/gmeg/mt-metadata/-/raw/v1.0.10/DISCLAIMER.md",
     "repositoryURL": "https://code.usgs.gov/gmeg/mt_metadata.git",
     "tags": [
       "magnetotellurics",

--- a/mt_metadata/__init__.py
+++ b/mt_metadata/__init__.py
@@ -39,7 +39,7 @@ you should only have to changes these dictionaries.
 
 __author__ = """Jared Peacock"""
 __email__ = "jpeacock@usgs.gov"
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 # =============================================================================
 # Imports

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -43,6 +43,7 @@ from mt_metadata.utils.validators import validate_attribute, validate_name
 
 from . import helpers, pydantic_helpers
 
+
 # =============================================================================
 #  Base class that everything else will inherit
 # =============================================================================
@@ -1213,7 +1214,17 @@ class MetadataBase(DotNotationBaseModel):
             if skip_none:
                 if value in NULL_VALUES:
                     continue
-            self.update_attribute(name, value)
+            if value is None:
+                try:
+                    self.update_attribute(name, value)
+                except Exception:
+                    logger.debug(
+                        f"Skipping attribute '{name}' because None is not valid "
+                        f"for this field; keeping existing value."
+                    )
+                    continue
+            else:
+                self.update_attribute(name, value)
 
     def to_json(
         self, nested: bool = False, indent: str = " " * 4, required: bool = True

--- a/mt_metadata/base/metadata.py
+++ b/mt_metadata/base/metadata.py
@@ -43,7 +43,6 @@ from mt_metadata.utils.validators import validate_attribute, validate_name
 
 from . import helpers, pydantic_helpers
 
-
 # =============================================================================
 #  Base class that everything else will inherit
 # =============================================================================

--- a/mt_metadata/common/fdsn.py
+++ b/mt_metadata/common/fdsn.py
@@ -16,7 +16,6 @@ class Fdsn(MetadataBase):
             default=None,
             description="Given FDSN archive ID name.",
             alias=None,
-            pattern="^[a-zA-Z0-9._-]*$",
             json_schema_extra={
                 "units": None,
                 "required": False,

--- a/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
@@ -611,7 +611,7 @@ class EMTFXML:
             }
 
             dipole_names = []
-            for d in self.field_notes.run_list[0].dipole:
+            for d in self.field_notes._run_list[0].dipole:
                 if isinstance(d.name, str):
                     dipole_names.append(d.name.lower())
                 else:
@@ -621,13 +621,13 @@ class EMTFXML:
             elif None in dipole_names:
                 index = dipole_names.index(None)
             else:
-                self.field_notes.run_list[0].magnetometer.append(
+                self.field_notes._run_list[0].dipole.append(
                     emtf_xml.Dipole(name=comp)
                 )
                 index = -1
 
             setattr(
-                self.field_notes.run_list[0].dipole[index],
+                self.field_notes._run_list[0].dipole[index],
                 e_dict[fkey],
                 value,
             )
@@ -679,7 +679,7 @@ class EMTFXML:
             }
 
             mag_names = []
-            for d in self.field_notes.run_list[0].magnetometer:
+            for d in self.field_notes._run_list[0].magnetometer:
                 if isinstance(d.name, str):
                     mag_names.append(d.name.lower())
                 else:
@@ -690,13 +690,13 @@ class EMTFXML:
             elif None in mag_names:
                 index = mag_names.index(None)
             else:
-                self.field_notes.run_list[0].magnetometer.append(
+                self.field_notes._run_list[0].magnetometer.append(
                     emtf_xml.Magnetometer(name=comp)
                 )
                 index = -1
 
             setattr(
-                self.field_notes.run_list[0].magnetometer[index],
+                self.field_notes._run_list[0].magnetometer[index],
                 m_dict[fkey],
                 value,
             )
@@ -779,13 +779,13 @@ class EMTFXML:
             if comment.count(":") >= 1:
                 key, value = [c.strip() for c in comment.split(":", 1)]
                 if "fieldnotes" in key:
-                    if len(self.field_notes.run_list) == 0:
-                        self.field_notes.run_list.append(emtf_xml.Run())
+                    if len(self.field_notes._run_list) == 0:
+                        self.field_notes._run_list.append(emtf_xml.Run())
 
                 if "datalogger" in key:
                     key, value = self._parse_comments_data_logger(key, value)
                     try:
-                        self.field_notes.run_list[0].update_attribute(key, value)
+                        self.field_notes._run_list[0].update_attribute(key, value)
                         key = None
                         value = None
                     except:

--- a/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/emtfxml.py
@@ -621,9 +621,7 @@ class EMTFXML:
             elif None in dipole_names:
                 index = dipole_names.index(None)
             else:
-                self.field_notes._run_list[0].dipole.append(
-                    emtf_xml.Dipole(name=comp)
-                )
+                self.field_notes._run_list[0].dipole.append(emtf_xml.Dipole(name=comp))
                 index = -1
 
             setattr(

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/copyright.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/copyright.py
@@ -3,7 +3,7 @@
 # =====================================================
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from mt_metadata.base import MetadataBase
 from mt_metadata.common.enumerations import ReleaseStatusEnum
@@ -99,6 +99,14 @@ class Copyright(MetadataBase):
             },
         ),
     ]
+
+    @field_validator("citation", mode="before")
+    @classmethod
+    def validate_citation(cls, value) -> Citation:
+        """Ensure citation is an instance of Citation, an empty element is None."""
+        if value is None:
+            return Citation()  # type: ignore
+        return value
 
     def read_dict(self, input_dict):
         """

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/emtf.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/emtf.py
@@ -32,7 +32,6 @@ class EMTF(MetadataBase):
             default="",
             description="ID given as the archive ID of the station",
             alias=None,
-            pattern="^[a-zA-Z0-9._-]*$",
             json_schema_extra={
                 "units": None,
                 "required": True,

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
@@ -11,7 +11,6 @@ Created on Wed Mar  8 19:53:04 2023
 from collections import OrderedDict
 from enum import Enum
 from xml.etree import cElementTree as et
-from enum import Enum
 
 from loguru import logger
 
@@ -123,7 +122,7 @@ def _write_single(
         if isinstance(value, Enum):
             element.text = str(value.value)
         else:
-          element.text = str(value)
+            element.text = str(value)
     return element
 
 

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
@@ -10,6 +10,7 @@ Created on Wed Mar  8 19:53:04 2023
 # =============================================================================
 from collections import OrderedDict
 from xml.etree import cElementTree as et
+from enum import Enum
 
 from loguru import logger
 
@@ -117,6 +118,9 @@ def _write_single(
 
     element = et.SubElement(parent, _capwords(key), attributes)
     if value not in NULL_VALUES:
+        # for enumerate objects
+        if isinstance(value, Enum):
+            element.text = str(value.value)
         element.text = str(value)
     return element
 

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/helpers.py
@@ -9,6 +9,7 @@ Created on Wed Mar  8 19:53:04 2023
 # Imports
 # =============================================================================
 from collections import OrderedDict
+from enum import Enum
 from xml.etree import cElementTree as et
 
 from loguru import logger
@@ -117,6 +118,8 @@ def _write_single(
 
     element = et.SubElement(parent, _capwords(key), attributes)
     if value not in NULL_VALUES:
+        if isinstance(value, Enum):
+            value = value.value
         element.text = str(value)
     return element
 

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
@@ -80,7 +80,7 @@ class Site(MetadataBase):
             default="",
             description="Station ID name.  This should be an alpha numeric name that is typically 5-6 characters long.  Commonly the project name in 2 or 3 letters and the station number.",
             alias=None,
-            pattern="^[a-zA-Z0-9]*$",
+            pattern="^[a-zA-Z0-9_-]*$",
             json_schema_extra={
                 "units": None,
                 "required": True,

--- a/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
+++ b/mt_metadata/transfer_functions/io/emtfxml/metadata/site.py
@@ -24,7 +24,6 @@ class Site(MetadataBase):
             default="",
             description="Name of the project",
             alias=None,
-            pattern="^[a-zA-Z0-9-_]*$",
             json_schema_extra={
                 "units": None,
                 "required": True,

--- a/mt_metadata/transfer_functions/tf/statistical_estimate.py
+++ b/mt_metadata/transfer_functions/tf/statistical_estimate.py
@@ -3,11 +3,13 @@
 # =====================================================
 from typing import Annotated
 
+import numpy as np
 from pydantic import Field, field_validator
 
 from mt_metadata.base import MetadataBase
 from mt_metadata.common.enumerations import ArrayDTypeEnum
 from mt_metadata.common.units import get_unit_object
+
 
 # =====================================================
 
@@ -56,7 +58,7 @@ class StatisticalEstimate(MetadataBase):
     ]
 
     input_channels: Annotated[
-        list[str] | str,
+        list[str] | str | np.ndarray,
         Field(
             default=[],
             description="List of input channels (sources)",
@@ -70,7 +72,7 @@ class StatisticalEstimate(MetadataBase):
     ]
 
     output_channels: Annotated[
-        list[str] | str,
+        list[str] | str | np.ndarray,
         Field(
             default=[],
             description="List of output channels (response).",
@@ -112,10 +114,12 @@ class StatisticalEstimate(MetadataBase):
 
     @field_validator("input_channels", "output_channels", mode="before")
     @classmethod
-    def validate_channels(cls, value: list[str] | str) -> list[str]:
+    def validate_channels(cls, value: list[str] | str | np.ndarray) -> list[str]:
         """convert channels to a list of single channels"""
         if isinstance(value, str):
             value = [v.strip() for v in value.split(",")]
+        elif isinstance(value, np.ndarray):
+            value = value.tolist()
         elif not isinstance(value, list):
             raise TypeError(
                 f"Input channels must be a list of channels, not {type(value)}."

--- a/mt_metadata/transfer_functions/tf/statistical_estimate.py
+++ b/mt_metadata/transfer_functions/tf/statistical_estimate.py
@@ -10,7 +10,6 @@ from mt_metadata.base import MetadataBase
 from mt_metadata.common.enumerations import ArrayDTypeEnum
 from mt_metadata.common.units import get_unit_object
 
-
 # =====================================================
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mt_metadata"
-version = "1.0.9"
+version = "1.0.10"
 description = "Metadata for magnetotelluric data"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
@@ -98,7 +98,7 @@ ignore-init-module-imports = true
 in-place = true
 
 [tool.bumpversion]
-current_version = "1.0.9"
+current_version = "1.0.10"
 commit = true
 tag = true
 

--- a/tests/common/test_fdsn.py
+++ b/tests/common/test_fdsn.py
@@ -39,12 +39,13 @@ def test_fdsn_custom_values():
     assert fdsn.alternate_network_code == "_INT-NON_FDSN"
 
 
-def test_fdsn_invalid_id():
+def test_fdsn_id_from_product_id():
     """
-    Test the Fdsn model with an invalid id.
+    Test the Fdsn model with an id composed from a project name.
     """
-    with pytest.raises(ValidationError):
-        Fdsn(id="MT@001")  # Invalid character in id
+    product_id = "Test Project Name.MT001.2020"
+
+    assert Fdsn(id=product_id).id == product_id
 
 
 def test_fdsn_invalid_network():

--- a/tests/transfer_functions/io/emtfxml/metadata/test_copyright.py
+++ b/tests/transfer_functions/io/emtfxml/metadata/test_copyright.py
@@ -375,6 +375,13 @@ class TestCopyrightReadDict:
         # Should not raise an exception (the helper may log a warning but that's expected)
         basic_copyright.read_dict(test_dict)
 
+    def test_read_dict_empty_citation(self):
+        """Test read_dict with the None that an empty Citation element reads as."""
+        copyright_obj = Copyright()
+        copyright_obj.read_dict({"copyright": {"citation": None}})
+
+        assert isinstance(copyright_obj.citation, Citation)
+
 
 class TestCopyrightEdgeCases:
     """Test Copyright edge cases and special scenarios."""

--- a/tests/transfer_functions/io/emtfxml/metadata/test_emtf.py
+++ b/tests/transfer_functions/io/emtfxml/metadata/test_emtf.py
@@ -41,6 +41,7 @@ from typing import Any, Dict, List
 import pytest
 
 from mt_metadata.common.enumerations import DataTypeEnum
+from mt_metadata.timeseries import Survey
 from mt_metadata.transfer_functions.io.emtfxml.metadata import EMTF
 
 
@@ -133,10 +134,10 @@ def performance_emtf_data() -> List[Dict[str, Any]]:
         ("test.123", True),  # Valid with period
         ("USMTArray.NVS11.2020", True),  # Valid example from field definition
         ("test-123", True),  # Valid with hyphen (now allowed)
-        ("test 123", False),  # Invalid with space
-        ("test@123", False),  # Invalid with special character
-        ("test/path", False),  # Invalid with slash
-        ("test#123", False),  # Invalid with hash
+        ("test 123", True),  # Valid with space (now allowed)
+        ("test@123", True),  # Valid with special character (now allowed)
+        ("test/path", True),  # Valid with slash (now allowed)
+        ("test#123", True),  # Valid with hash (now allowed)
     ]
 )
 def product_id_test_cases(request) -> tuple[str, bool]:
@@ -285,22 +286,12 @@ class TestEmtfFieldValidation:
             basic_emtf.product_id = pattern
             assert basic_emtf.product_id == pattern
 
-    def test_product_id_invalid_patterns(self):
-        """Test invalid product_id patterns that should fail validation."""
-        invalid_patterns = [
-            "test 123",  # Space not allowed
-            "test@domain.com",  # Special characters not allowed
-            "test/path",  # Slash not allowed
-            "test#123",  # Hash not allowed
-            "test%123",  # Percent not allowed
-            "test&123",  # Ampersand not allowed
-            "test+123",  # Plus not allowed
-            "test=123",  # Equal not allowed
-        ]
+    def test_product_id_from_survey_project(self):
+        """Test product_id accepts an id composed from a survey project name."""
+        survey = Survey(project="Test Project Name")
+        product_id = f"{survey.project}.MT001.2020"
 
-        for pattern in invalid_patterns:
-            with pytest.raises(Exception):  # Pydantic ValidationError
-                EMTF(product_id=pattern)  # type: ignore
+        assert EMTF(product_id=product_id).product_id == product_id  # type: ignore
 
     def test_tags_assignment(self, basic_emtf):
         """Test assignment of tags field."""
@@ -681,33 +672,28 @@ class TestEmtfSpecialCases:
         assert emtf.notes is None
 
     def test_pattern_validation_comprehensive(self):
-        """Test comprehensive pattern validation for product_id."""
-        # Test edge cases for allowed pattern: ^[a-zA-Z0-9._-]*$
+        """Test comprehensive value handling for product_id."""
         test_cases = [
-            ("", True),  # Empty string
-            ("A", True),  # Single letter
-            ("1", True),  # Single number
-            ("A1", True),  # Letter and number
-            ("1A", True),  # Number and letter
-            ("ABC123DEF456", True),  # Long alphanumeric
-            ("123456789", True),  # Long numeric
-            ("ABCDEFGHIJ", True),  # Long alphabetic
-            ("test-123", True),  # Hyphen allowed
-            ("test_123", True),  # Underscore allowed
-            ("test.123", True),  # Period allowed
-            ("test.-_123", True),  # Mix of allowed special chars
-            ("test@123", False),  # @ not allowed
-            ("test 123", False),  # Space not allowed
-            ("test/123", False),  # Slash not allowed
+            "",  # Empty string
+            "A",  # Single letter
+            "1",  # Single number
+            "A1",  # Letter and number
+            "1A",  # Number and letter
+            "ABC123DEF456",  # Long alphanumeric
+            "123456789",  # Long numeric
+            "ABCDEFGHIJ",  # Long alphabetic
+            "test-123",  # Hyphen
+            "test_123",  # Underscore
+            "test.123",  # Period
+            "test.-_123",  # Mix of special chars
+            "test@123",  # At sign
+            "test 123",  # Space, as a project name gives
+            "test/123",  # Slash
         ]
 
-        for test_value, should_be_valid in test_cases:
-            if should_be_valid:
-                emtf = EMTF(product_id=test_value)  # type: ignore
-                assert emtf.product_id == test_value
-            else:
-                with pytest.raises(Exception):
-                    EMTF(product_id=test_value)  # type: ignore
+        for test_value in test_cases:
+            emtf = EMTF(product_id=test_value)  # type: ignore
+            assert emtf.product_id == test_value
 
     def test_enum_value_persistence(self, basic_emtf):
         """Test that enum values persist correctly through operations."""

--- a/tests/transfer_functions/io/emtfxml/metadata/test_site.py
+++ b/tests/transfer_functions/io/emtfxml/metadata/test_site.py
@@ -26,7 +26,7 @@ import pytest
 
 from mt_metadata.common import Comment
 from mt_metadata.common.mttime import MTime
-from mt_metadata.timeseries import Survey
+from mt_metadata.timeseries import Station, Survey
 from mt_metadata.transfer_functions.io.emtfxml.metadata import (
     DataQualityNotes,
     DataQualityWarnings,
@@ -181,8 +181,8 @@ def run_list_data(request):
         ("project", "test 123", True),  # Valid with space (now allowed)
         ("id", "MT001", True),  # Valid alphanumeric
         ("id", "abc123", True),  # Valid lowercase
-        ("id", "MT-001", False),  # Invalid hyphen (still not allowed for id)
-        ("id", "MT_001", False),  # Invalid underscore (still not allowed for id)
+        ("id", "MT-001", True),  # Valid with hyphen (now allowed)
+        ("id", "MT_001", True),  # Valid with underscore (now allowed)
         ("id", "MT 001", False),  # Invalid space
     ]
 )
@@ -329,6 +329,11 @@ class TestSiteFieldValidation:
         """Test project accepts a project name held by a Survey."""
         survey = Survey(project="Test Project Name")
         assert Site(project=survey.project).project == survey.project
+
+    def test_id_from_station(self):
+        """Test id accepts a station id held by a Station."""
+        station = Station(id="MT_001")
+        assert Site(id=station.id).id == station.id
 
     # @pytest.mark.skip(
     #     reason="year_collected conversion has complex interaction with other validators"
@@ -506,8 +511,6 @@ class TestSiteEdgeCases:
     def test_invalid_pattern_fields(self):
         """Test validation errors for pattern-restricted fields."""
         invalid_patterns = [
-            ("id", "MT-001"),  # Hyphen not allowed for id
-            ("id", "MT_001"),  # Underscore not allowed for id
             ("id", "MT 001"),  # Space not allowed
             ("id", "MT@001"),  # Special char not allowed
         ]

--- a/tests/transfer_functions/io/emtfxml/metadata/test_site.py
+++ b/tests/transfer_functions/io/emtfxml/metadata/test_site.py
@@ -26,6 +26,7 @@ import pytest
 
 from mt_metadata.common import Comment
 from mt_metadata.common.mttime import MTime
+from mt_metadata.timeseries import Survey
 from mt_metadata.transfer_functions.io.emtfxml.metadata import (
     DataQualityNotes,
     DataQualityWarnings,
@@ -177,7 +178,7 @@ def run_list_data(request):
         ("project", "TEST", True),  # Valid uppercase
         ("project", "test-123", True),  # Valid with hyphen (now allowed)
         ("project", "test_123", True),  # Valid with underscore (now allowed)
-        ("project", "test 123", False),  # Invalid space
+        ("project", "test 123", True),  # Valid with space (now allowed)
         ("id", "MT001", True),  # Valid alphanumeric
         ("id", "abc123", True),  # Valid lowercase
         ("id", "MT-001", False),  # Invalid hyphen (still not allowed for id)
@@ -323,6 +324,11 @@ class TestSiteFieldValidation:
             # Should raise a validation error
             with pytest.raises(ValueError):
                 Site(**{field_name: value})
+
+    def test_project_from_survey(self):
+        """Test project accepts a project name held by a Survey."""
+        survey = Survey(project="Test Project Name")
+        assert Site(project=survey.project).project == survey.project
 
     # @pytest.mark.skip(
     #     reason="year_collected conversion has complex interaction with other validators"
@@ -500,10 +506,6 @@ class TestSiteEdgeCases:
     def test_invalid_pattern_fields(self):
         """Test validation errors for pattern-restricted fields."""
         invalid_patterns = [
-            ("project", "test name"),  # Space not allowed
-            ("project", "test@name"),  # Special char not allowed
-            ("project", "test/name"),  # Slash not allowed
-            ("project", "test%name"),  # Percent not allowed
             ("id", "MT-001"),  # Hyphen not allowed for id
             ("id", "MT_001"),  # Underscore not allowed for id
             ("id", "MT 001"),  # Space not allowed

--- a/tests/transfer_functions/io/emtfxml/test_tf_write.py
+++ b/tests/transfer_functions/io/emtfxml/test_tf_write.py
@@ -27,8 +27,10 @@ import numpy as np
 import pytest
 
 from mt_metadata import TF_XML
+from mt_metadata.timeseries import Run
 from mt_metadata.transfer_functions.core import TF
 from mt_metadata.transfer_functions.io.emtfxml import EMTFXML
+from mt_metadata.transfer_functions.tf import Station
 
 
 # =============================================================================
@@ -471,6 +473,46 @@ class TestEMTFXMLWriteFile:
     def test_read_written_file(self, original_emtfxml, written_fn):
         """Test a written file can be read back in."""
         assert original_emtfxml.sub_type == EMTFXML(written_fn).sub_type
+
+
+class TestEMTFXMLWriteFieldNoteComments:
+    """Test station comments that carry field note information."""
+
+    @pytest.fixture
+    def station(self):
+        """Create station metadata whose comments hold field note information."""
+        station = Station(id="MT001")
+        station.add_run(Run(id="MT001a", sample_rate=1.0))
+        station.comments.value = (
+            "fieldnotes.datalogger.manufacturer = Data Logger Co\n"
+            "fieldnotes.electrode_ex.manufacturer = Electrode Co\n"
+            "fieldnotes.magnetometer_hx.manufacturer = Magnetometer Co"
+        )
+        return station
+
+    def test_field_note_run(self, station):
+        """Test the comment values are read into the field notes."""
+        emtfxml = EMTFXML()
+        emtfxml.station_metadata = station
+
+        run = emtfxml.field_notes._run_list[0]
+        assert run.instrument.manufacturer == "Data Logger Co"
+        assert run.dipole[0].manufacturer == "Electrode Co"
+        assert run.magnetometer[0].manufacturer == "Magnetometer Co"
+
+    def test_field_notes_written(self, station, tmp_path):
+        """Test the comment values are written to the XML file."""
+        emtfxml = EMTFXML()
+        emtfxml.station_metadata = station
+        emtfxml.data.period = np.array([1.0, 2.0])
+
+        fn = tmp_path / "field_notes.xml"
+        emtfxml.write(fn)
+
+        written = fn.read_text()
+        assert "Data Logger Co" in written
+        assert "Electrode Co" in written
+        assert "Magnetometer Co" in written
 
 
 # =============================================================================

--- a/tests/transfer_functions/io/emtfxml/test_tf_write.py
+++ b/tests/transfer_functions/io/emtfxml/test_tf_write.py
@@ -454,6 +454,25 @@ class TestEMTFXMLWriteIntegration:
             assert np.allclose(original_emtfxml.data.t, tf_roundtrip.data.t)
 
 
+class TestEMTFXMLWriteFile:
+    """Test writing an EMTFXML file and reading it back."""
+
+    @pytest.fixture(scope="class")
+    def written_fn(self, original_emtfxml, tmp_path_factory):
+        """Write the original EMTFXML object to a file."""
+        fn = tmp_path_factory.mktemp("emtfxml") / "written.xml"
+        original_emtfxml.write(fn)
+        return fn
+
+    def test_sub_type_element(self, written_fn):
+        """Test SubType is written as the enum value."""
+        assert "<SubType>MT_TF</SubType>" in written_fn.read_text()
+
+    def test_read_written_file(self, original_emtfxml, written_fn):
+        """Test a written file can be read back in."""
+        assert original_emtfxml.sub_type == EMTFXML(written_fn).sub_type
+
+
 # =============================================================================
 # Performance and Edge Case Tests
 # =============================================================================


### PR DESCRIPTION
Following on PR #287 and fix to #286 these are updates to EMTFXML.

From PR #287:

Seven commits, one per defect, each with a test that fails before the fix:

- Write enum values in EMTF XML so files can be read back
- Accept free form project names in EMTF XML
- Allow underscores and hyphens in EMTF XML station ids
- Read field note comments into the field notes run list
- Allow any archive id in the EMTF XML product id
- Allow any archive id in the FDSN id
- Read an empty Citation element as a default Citation

The full test suite passes. After these changes all EDI files in my test set (five AusLAMP surveys) write to EMTF XML and read back without error.

- In addition any Enum type object will now use the `value` attribute to print a nice string.